### PR TITLE
CORE-8177 Update compojure-api version to 1.1.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,13 +6,13 @@
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [cheshire "5.5.0"
+                 [cheshire "5.6.3"
                   :exclusions [[com.fasterxml.jackson.dataformat/jackson-dataformat-cbor]
                                [com.fasterxml.jackson.dataformat/jackson-dataformat-smile]
                                [com.fasterxml.jackson.core/jackson-annotations]
                                [com.fasterxml.jackson.core/jackson-databind]
                                [com.fasterxml.jackson.core/jackson-core]]]
                  [clj-time "0.9.0"] ; required due to bug in lein-ring
-                 [metosin/compojure-api "0.24.5"]]
+                 [metosin/compojure-api "1.1.8"]]
   :profiles {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]]
                    :plugins [[lein-ring "0.9.6"]]}})

--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,4 @@
                                [com.fasterxml.jackson.core/jackson-annotations]
                                [com.fasterxml.jackson.core/jackson-databind]
                                [com.fasterxml.jackson.core/jackson-core]]]
-                 [clj-time "0.9.0"] ; required due to bug in lein-ring
-                 [metosin/compojure-api "1.1.8"]]
-  :profiles {:dev {:dependencies [[javax.servlet/servlet-api "2.5"]]
-                   :plugins [[lein-ring "0.9.6"]]}})
+                 [metosin/compojure-api "1.1.8"]])

--- a/src/common_swagger_api/schema.clj
+++ b/src/common_swagger_api/schema.clj
@@ -30,12 +30,6 @@
    POST
    PUT])
 
-;; extend schema/Any so that these params still display in the swagger docs.
-(extend-type schema.core.AnythingSchema
-  json-schema/JsonSchema
-  (json-schema/convert [_ _]
-    {:type "any"}))
-
 (def ->required-key s/explicit-schema-key)
 
 (defn ->required-param

--- a/src/common_swagger_api/schema.clj
+++ b/src/common_swagger_api/schema.clj
@@ -11,25 +11,24 @@
   [compojure.api.sweet
    api
    defapi
-   middlewares
 
    describe
 
-   swagger-ui
-   swagger-docs
-   swaggered
+   swagger-routes
 
-   defroutes*
-   context*
+   defroutes
+   undocumented
+   middleware
+   context
 
-   GET*
-   ANY*
-   HEAD*
-   PATCH*
-   DELETE*
-   OPTIONS*
-   POST*
-   PUT*])
+   GET
+   ANY
+   HEAD
+   PATCH
+   DELETE
+   OPTIONS
+   POST
+   PUT])
 
 ;; extend schema/Any so that these params still display in the swagger docs.
 (extend-type schema.core.AnythingSchema


### PR DESCRIPTION
Update versions for compojure-api and some of its dependencies.
We also no longer need to extend `schema/Any`, since compojure-api 1.1.8 now displays `schema/Any` params in swagger docs as empty objects.
