### PR TITLE
CORE-5810 Add clojure-commons.error-codes response schemas.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -8,4 +8,5 @@
   :plugins [[test2junit "1.2.2"]]
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [cheshire "5.6.3"]
-                 [metosin/compojure-api "1.1.8"]])
+                 [metosin/compojure-api "1.1.8"]
+                 [org.cyverse/clojure-commons "2.8.1-SNAPSHOT"]])

--- a/src/common_swagger_api/schema.clj
+++ b/src/common_swagger_api/schema.clj
@@ -103,8 +103,9 @@
     :error_code (describe (s/enum ERR_ILLEGAL_ARGUMENT) "Illegal Argument error code")))
 
 (s/defschema ErrorResponseUnchecked
-  (assoc ErrorResponse
-    :error_code (describe (s/enum ERR_UNCHECKED_EXCEPTION) "Unchecked error code")))
+  {:error_code              (describe (s/enum ERR_UNCHECKED_EXCEPTION ERR_SCHEMA_VALIDATION)
+                                      "Response schema validation and Unchecked error codes")
+   (s/optional-key :reason) (describe s/Any "A brief text or object describing the reason for the error")})
 
 (defrecord DocOnly [schema-real schema-doc]
   s/Schema

--- a/src/common_swagger_api/schema.clj
+++ b/src/common_swagger_api/schema.clj
@@ -1,5 +1,6 @@
 (ns common-swagger-api.schema
   (:use [clojure.string :only [blank?]]
+        [clojure-commons.error-codes]
         [potemkin :only [import-vars]])
   (:require compojure.api.sweet
             [ring.swagger.json-schema :as json-schema]
@@ -96,6 +97,14 @@
 (s/defschema ErrorResponse
   {:error_code              (describe NonBlankString "The code identifying the type of error")
    (s/optional-key :reason) (describe NonBlankString "A brief description of the reason for the error")})
+
+(s/defschema ErrorResponseIllegalArgument
+  (assoc ErrorResponse
+    :error_code (describe (s/enum ERR_ILLEGAL_ARGUMENT) "Illegal Argument error code")))
+
+(s/defschema ErrorResponseUnchecked
+  (assoc ErrorResponse
+    :error_code (describe (s/enum ERR_UNCHECKED_EXCEPTION) "Unchecked error code")))
 
 (defrecord DocOnly [schema-real schema-doc]
   s/Schema

--- a/src/common_swagger_api/schema.clj
+++ b/src/common_swagger_api/schema.clj
@@ -98,6 +98,10 @@
   {:error_code              (describe NonBlankString "The code identifying the type of error")
    (s/optional-key :reason) (describe NonBlankString "A brief description of the reason for the error")})
 
+(s/defschema ErrorResponseNotFound
+  (assoc ErrorResponse
+    :error_code (describe (s/enum ERR_NOT_FOUND) "Not Found error code")))
+
 (s/defschema ErrorResponseIllegalArgument
   (assoc ErrorResponse
     :error_code (describe (s/enum ERR_ILLEGAL_ARGUMENT) "Illegal Argument error code")))


### PR DESCRIPTION
Adds `ERR_ILLEGAL_ARGUMENT` and `ERR_UNCHECKED_EXCEPTION` response schemas, to allow endpoints to document non-200 error responses.
