### PR TITLE
CORE-11 Add swagger docs :description-file param.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ bin
 /.settings
 build.xml
 test2junit
+.DS_Store
+*.iml
+.idea

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/common-swagger-api "2.9.4-SNAPSHOT"
+(defproject org.cyverse/common-swagger-api "2.10.0-SNAPSHOT"
   :description "Common library for Swagger documented RESTful APIs"
   :url "https://github.com/cyverse-de/common-swagger-api"
   :license {:name "BSD"

--- a/src/common_swagger_api/routes.clj
+++ b/src/common_swagger_api/routes.clj
@@ -1,4 +1,10 @@
-(ns common-swagger-api.routes)
+(ns common-swagger-api.routes
+  (:require [clojure.java.io :as io]
+            [compojure.api.meta]))
+
+(defmethod compojure.api.meta/restructure-param :description-file
+  [_ path acc]
+  (update-in acc [:swagger] assoc :description (slurp (io/resource path))))
 
 (defn get-endpoint-delegate-block
   [service endpoint]


### PR DESCRIPTION
This PR will add the `:description-file` docs param to `common-swagger-api.routes`, and bump the version to `2.10.0-SNAPSHOT`.