### PR TITLE
CORE-11 Migrate /apps listing schemas and docs.

### DIFF
--- a/resources/docs/apps/apps-listing.md
+++ b/resources/docs/apps/apps-listing.md
@@ -1,0 +1,9 @@
+This service allows users to get a paged listing of all Apps accessible to the user.
+If the `search` parameter is included, then the results are filtered by
+the App name, description, integrator's name, tool name, or category name the app is under.
+
+#### Delegates to metadata service
+    POST /avus/filter-targets
+
+#### Delegates to metadata service
+    POST /ontologies/{ontology-version}/filter-targets

--- a/src/common_swagger_api/schema/apps/rating.clj
+++ b/src/common_swagger_api/schema/apps/rating.clj
@@ -1,0 +1,19 @@
+(ns common-swagger-api.schema.apps.rating
+  (:use [common-swagger-api.schema :only [describe]]
+        [schema.core :only [defschema optional-key]]))
+
+(def UserRatingParam (describe Long "The current user's rating for this App"))
+(def CommentIdParam (describe Long "The ID of the current user's rating comment for this App"))
+
+(defschema RatingResponse
+  {:average (describe Double "The average user rating for this App")
+   :total   (describe Long "The total number of user ratings for this App")})
+
+(defschema Rating
+  (merge RatingResponse
+    {(optional-key :user)       UserRatingParam
+     (optional-key :comment_id) CommentIdParam}))
+
+(defschema RatingRequest
+  {:rating                    UserRatingParam
+   (optional-key :comment_id) CommentIdParam})


### PR DESCRIPTION
This PR will migrate the initial `/apps` endpoint docs, starting with just the `/apps` search endpoint for this PR.

These changes were already approved in a previous version of #9.