### PR TITLE
CORE-145: dependency updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test2junit
 *.iml
 .idea
 .nrepl-port
+.eastwood

--- a/project.clj
+++ b/project.clj
@@ -5,13 +5,13 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
-  :dependencies [[org.clojure/clojure "1.8.0"]
-                 [cheshire "5.6.3"]
-                 [metosin/compojure-api "1.1.8"]
+  :dependencies [[org.clojure/clojure "1.10.0"]
+                 [cheshire "5.8.1"]
+                 [metosin/compojure-api "1.1.12"]
                  [metosin/schema-tools "0.11.0"]
-                 [org.cyverse/clojure-commons "2.8.1"]
+                 [org.cyverse/clojure-commons "3.0.3-SNAPSHOT"]
                  [org.cyverse/heuristomancer "2.8.6"]
                  [org.flatland/ordered "1.5.7"]]
   :eastwood {:linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
   :plugins [[test2junit "1.2.2"]
-            [jonase/eastwood "0.3.4"]])
+            [jonase/eastwood "0.3.5"]])


### PR DESCRIPTION
The primary purpose of this change was to switch to `compojure-api` version 1.1.12, which supports the `charset` attribute of the `Boundary` header. I thought I'd update several other dependencies at the same time.