### PR TITLE
CORE-11 Migrate more schemas and docs from apps.routes.app

### DIFF
--- a/resources/docs/apps/app-details.md
+++ b/resources/docs/apps/app-details.md
@@ -1,0 +1,5 @@
+This service is used by the DE to obtain high-level details about a single App.
+
+#### Delegates to metadata service
+    POST /ontologies/{ontology-version}/filter
+Please see the metadata service documentation for information about the `hierarchies` response field.

--- a/resources/docs/apps/app-label-update.md
+++ b/resources/docs/apps/app-label-update.md
@@ -1,0 +1,16 @@
+This service is capable of updating just the labels within a single-step app,
+and it allows apps that have already been made available for public use to be updated,
+which helps to eliminate administrative thrash for app updates that only correct typographical errors.
+The app's name must not duplicate the name of any other app (visible to the requesting user)
+under the same categories as this app.
+Upon error, the response body contains an error code along with some additional information about the error.
+
+**Note**: Although this endpoint accepts all App fields,
+only the `name` (except in parameters and parameter arguments),
+`description`, `label`, and `display` (only in parameter arguments)
+fields will be processed and updated by this endpoint.
+
+#### Delegates to metadata service
+    POST /avus/filter-targets
+    GET /avus/{target-type}/{target-id}
+Where `{target-type}` is `app`.

--- a/resources/docs/apps/app-update.md
+++ b/resources/docs/apps/app-update.md
@@ -1,0 +1,8 @@
+This service updates a single-step App in the database, as long as the App has not been submitted for public use,
+and the app's name must not duplicate the name of any other app (visible to the requesting user)
+under the same categories as this app.
+
+#### Delegates to metadata service
+    POST /avus/filter-targets
+    GET /avus/{target-type}/{target-id}
+Where `{target-type}` is `app`.

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -1,14 +1,17 @@
 (ns common-swagger-api.schema.apps
-  (:use [common-swagger-api.schema :only [describe
+  (:use [common-swagger-api.schema :only [->optional-param
+                                          describe
                                           optional-key->keyword
                                           NonBlankString
                                           PagingParams
                                           SortFieldDocs
                                           SortFieldOptionalKey]]
         [common-swagger-api.schema.apps.rating :only [Rating]]
+        [common-swagger-api.schema.tools :only [Tool ToolDetails ToolListingImage ToolListingItem]]
         [schema.core :only [defschema
                             enum
                             optional-key
+                            recursive
                             Any
                             Bool
                             Keyword]])
@@ -23,17 +26,196 @@
    <b>Note</b>: an attempt to delete an app that is already marked as deleted is treated as a no-op rather than an error condition.
    If the App doesn't exist in the database at all, however, then that is treated as an error condition.")
 
+(def AppCategoryIdPathParam (describe UUID "The App Category's UUID"))
 (def AppDeletedParam (describe Boolean "Whether the App is marked as deleted"))
 (def AppDisabledParam (describe Boolean "Whether the App is marked as disabled"))
+(def AppDocParam (describe String "The App's documentation"))
 (def AppDocUrlParam (describe String "The App's documentation URL"))
 (def AppIdParam (describe UUID "A UUID that is used to identify the App"))
 (def AppPublicParam (describe Boolean "Whether the App has been published and is viewable by all users"))
-(def SystemId (describe NonBlankString "The ID of the app execution system"))
+(def AppReferencesParam (describe [String] "The App's references"))
 (def StringAppIdParam (describe NonBlankString "The App identifier"))
+(def SystemId (describe NonBlankString "The ID of the app execution system"))
+(def ToolDeprecatedParam (describe Boolean "Flag indicating if this Tool has been deprecated"))
+
+(def OptionalDebugKey (optional-key :debug))
+(def OptionalDeprecatedKey (optional-key :deprecated))
+(def OptionalGroupsKey (optional-key :groups))
+(def OptionalToolsKey (optional-key :tools))
+(def OptionalParametersKey (optional-key :parameters))
+(def OptionalParameterArgumentsKey (optional-key :arguments))
+
+(def ToolListDocs "The tools used to execute the App")
+(def GroupListDocs "The list of Parameter Groups associated with the App")
+(def ParameterListDocs "The list of Parameters in this Group")
+(def ListItemOrTreeDocs
+  "The List Parameter's arguments. Only used in cases where the user is given a fixed number of
+   values to choose from. This can occur for Parameters such as `TextSelection` or
+   `IntegerSelection` Parameters")
+(def TreeSelectorParameterListDocs "The TreeSelector root's arguments")
+(def TreeSelectorGroupListDocs "The TreeSelector root's groups")
+(def TreeSelectorGroupParameterListDocs "The TreeSelector Group's arguments")
+(def TreeSelectorGroupGroupListDocs "The TreeSelector Group's groups")
+(def AppListingJobStatsDocs "Some launch statistics associated with the App")
 
 (defschema IncludeHiddenParams
   {(optional-key :include-hidden)
    (describe Boolean "True if hidden elements should be included in the results.")})
+
+(defschema AppParameterListItem
+  {:id                         (describe UUID "A UUID that is used to identify the List Item")
+   (optional-key :name)        (describe String "The List Item's name")
+   (optional-key :value)       (describe String "The List Item's value")
+   (optional-key :description) (describe String "The List Item's description")
+   (optional-key :display)     (describe String "The List Item's display label")
+   (optional-key :isDefault)   (describe Boolean "Flags this Item as the List's default selection")})
+
+(defschema AppParameterListGroup
+  (merge AppParameterListItem
+         {OptionalParameterArgumentsKey
+          (describe [AppParameterListItem] TreeSelectorGroupParameterListDocs)
+
+          OptionalGroupsKey
+          (describe [(recursive #'AppParameterListGroup)] TreeSelectorGroupGroupListDocs)}))
+
+(defschema AppParameterListItemOrTree
+  (merge AppParameterListItem
+         {(optional-key :isSingleSelect)
+          (describe Boolean "The TreeSelector root's single-selection flag")
+
+          (optional-key :selectionCascade)
+          (describe String "The TreeSelector root's cascace option")
+
+          OptionalParameterArgumentsKey
+          (describe [AppParameterListItem] TreeSelectorParameterListDocs)
+
+          OptionalGroupsKey
+          (describe [AppParameterListGroup] TreeSelectorGroupListDocs)}))
+
+(defschema AppParameterValidator
+  {:type
+   (describe String
+             "The validation rule's type, which describes how a property value should be validated. For
+              example, if the type is `IntAbove` then the property value entered by the user must be an
+              integer above a specific value, which is specified in the parameter list. You can use the
+              `rule-types` endpoint to get a list of validation rule types")
+
+   :params
+   (describe [Any]
+             "The list of parameters to use when validating a Parameter value. For example, to ensure that a
+              Parameter contains a value that is an integer greater than zero, you would use a validation
+              rule of type `IntAbove` along with a parameter list of `[0]`")})
+
+(defschema AppFileParameters
+  {(optional-key :format)
+   (describe String "The Input/Output Parameter's file format")
+
+   (optional-key :file_info_type)
+   (describe String "The Input/Output Parameter's info type")
+
+   (optional-key :is_implicit)
+   (describe Boolean
+             "Whether the Output Parameter name is specified on the command line (but still be referenced in
+              Pipelines), or implicitly determined by the app itself. If the output file name is implicit
+              then the output file name either must always be the same or it must follow a naming convention
+              that can easily be matched with a glob pattern")
+
+   (optional-key :repeat_option_flag)
+   (describe Boolean
+             "Whether or not the command-line option flag should preceed each file of a MultiFileSelector
+             on the command line when the App is run")
+
+   (optional-key :data_source)
+   (describe String "The Output Parameter's source")
+
+   (optional-key :retain)
+   (describe Boolean
+             "Whether or not the Input should be copied back to the job output directory in iRODS")})
+
+(defschema AppParameter
+  {:id
+   (describe UUID "A UUID that is used to identify the Parameter")
+
+   (optional-key :name)
+   (describe String
+             "The Parameter's name. In most cases, this field indicates the command-line option used to
+              identify the Parameter on the command line. In these cases, the Parameter is assumed to be
+              positional and no command-line option is used if the name is blank. For Parameters that
+              specify a limited set of selection values, however, this is not the case. Instead, the
+              Parameter arguments specify both the command-line flag and the Parameter value to use for each
+              option that is selected")
+
+   (optional-key :defaultValue)
+   (describe Any "The Parameter's default value")
+
+   (optional-key :value)
+   (describe Any "The Parameter's value, used for previewing this parameter on the command-line.")
+
+   (optional-key :label)
+   (describe String "The Parameter's prompt to display in the UI")
+
+   (optional-key :description)
+   (describe String "The Parameter's description")
+
+   (optional-key :order)
+   (describe Long
+             "The relative command-line order for the Parameter. If this field is not specified then the
+              arguments will appear on the command-line in the order in which they appear in the import JSON.
+              If you're not specifying the order, please be sure that the argument order is unimportant for
+              the tool being integrated")
+
+   (optional-key :required)
+   (describe Boolean "Whether or not a value is required for this Parameter")
+
+   (optional-key :isVisible)
+   (describe Boolean "The Parameter's intended visibility in the job submission UI")
+
+   (optional-key :omit_if_blank)
+   (describe Boolean
+             "Whether the command-line option should be omitted if the Parameter value is blank. This is
+              most useful for optional arguments that use command-line flags in conjunction with a value. In
+              this case, it is an error to include the command-line flag without a corresponding value. This
+              flag indicates that the command-line flag should be omitted if the value is blank. This can
+              also be used for positional arguments, but this flag tends to be useful only for trailing
+              positional arguments")
+
+   :type
+   (describe String
+             "The Parameter's type name. Must contain the name of one of the Parameter types defined in the
+              database. You can get the list of defined and undeprecated Parameter types using the
+              `parameter-types` endpoint")
+
+   (optional-key :file_parameters)
+   (describe AppFileParameters "The File Parameter specific details")
+
+   OptionalParameterArgumentsKey
+   (describe [AppParameterListItemOrTree] ListItemOrTreeDocs)
+
+   (optional-key :validators)
+   (describe [AppParameterValidator]
+             "The Parameter's validation rules, which contains a list of rules that can be used to verify
+              that Parameter values entered by a user are valid. Note that in cases where the user is given
+              a list of possibilities to choose from, no validation rules are required because the selection
+              list itself can be used to validate the Parameter value")})
+
+(defschema AppGroup
+  {:id
+   (describe UUID "A UUID that is used to identify the Parameter Group")
+
+   (optional-key :name)
+   (describe String "The Parameter Group's name")
+
+   (optional-key :description)
+   (describe String "The Parameter Group's description")
+
+   :label
+   (describe String "The label used to identify the Parameter Group in the UI")
+
+   (optional-key :isVisible)
+   (describe Boolean "The Parameter Group's intended visibility in the job submission UI")
+
+   OptionalParametersKey
+   (describe [AppParameter] ParameterListDocs)})
 
 (defschema AppBase
   {:id                              AppIdParam
@@ -42,6 +224,141 @@
    (optional-key :integration_date) (describe Date "The App's Date of public submission")
    (optional-key :edited_date)      (describe Date "The App's Date of its last edit")
    (optional-key :system_id)        SystemId})
+
+(defschema App
+  (merge AppBase
+         {OptionalToolsKey           (describe [(merge Tool {OptionalDeprecatedKey ToolDeprecatedParam})] ToolListDocs)
+          (optional-key :references) AppReferencesParam
+          OptionalGroupsKey          (describe [AppGroup] GroupListDocs)}))
+
+(defschema AppFileParameterDetails
+  {:id          (describe String "The Parameter's ID")
+   :name        (describe String "The Parameter's name")
+   :description (describe String "The Parameter's description")
+   :label       (describe String "The Input Parameter's label or the Output Parameter's value")
+   :format      (describe String "The Parameter's file format")
+   :required    (describe Boolean "Whether or not a value is required for this Parameter")})
+
+(defschema AppTask
+  {:system_id           (describe String "The Task's System ID")
+   :id                  (describe String "The Task's ID")
+   :name                (describe String "The Task's name")
+   :description         (describe String "The Task's description")
+   (optional-key :tool) ToolDetails
+   :inputs              (describe [AppFileParameterDetails] "The Task's input parameters")
+   :outputs             (describe [AppFileParameterDetails] "The Task's output parameters")})
+
+(defschema AppTaskListing
+  (assoc AppBase
+    :id    (describe String "The App's ID.")
+    :tasks (describe [AppTask] "The App's tasks")))
+
+(defschema AppParameterJobView
+  (assoc AppParameter
+    :id
+    (describe String
+              "A string consisting of the App's step ID and the Parameter ID separated by an underscore.
+               Both identifiers are necessary because the same task may be associated with a single App,
+               which would cause duplicate keys in the job submission JSON. The step ID is prepended to
+               the Parameter ID in order to ensure that all parameter value keys are unique.")))
+
+(defschema AppGroupJobView
+  (assoc AppGroup
+    :id                   (describe String "The app group ID.")
+    :step_number          (describe Long "The step number associated with this parameter group")
+    OptionalParametersKey (describe [AppParameterJobView] ParameterListDocs)))
+
+(defschema AppJobView
+  (assoc AppBase
+    :app_type         (describe String "DE or External.")
+    :id               (describe String "The app ID.")
+    :label            (describe String "An alias for the App's name")
+    :deleted          AppDeletedParam
+    :disabled         AppDisabledParam
+    OptionalDebugKey  (describe Boolean "True if input files should be retained for the job by default.")
+    OptionalGroupsKey (describe [AppGroupJobView] GroupListDocs)))
+
+(defschema AppDetailCategory
+  {:id AppCategoryIdPathParam
+   :name (describe String "The App Category's name")})
+
+(defschema AppDetailsTool
+  (merge Tool
+         {:id                       (describe String "The tool identifier.")
+          (optional-key :container) ToolListingImage}))
+
+(defschema AppListingJobStats
+  {:job_count_completed
+   (describe Long "The number of times this app has run to `Completed` status")
+
+   (optional-key :job_last_completed)
+   (describe Date "The last date this app has run to `Completed` status")})
+
+(defschema AppDetails
+  (merge AppBase
+         {:id
+          (describe String "The app identifier.")
+
+          :tools
+          (describe [AppDetailsTool] ToolListDocs)
+
+          :deleted
+          AppDeletedParam
+
+          :disabled
+          AppDisabledParam
+
+          :integrator_email
+          (describe String "The App integrator's email address.")
+
+          :integrator_name
+          (describe String "The App integrator's full name.")
+
+          (optional-key :wiki_url)
+          AppDocUrlParam
+
+          :references
+          AppReferencesParam
+
+          (optional-key :job_stats)
+          (describe AppListingJobStats AppListingJobStatsDocs)
+
+          (optional-key :hierarchies)
+          (describe Any
+                    "The ontology hierarchies associated with the App")
+
+          :categories
+          (describe [AppDetailCategory]
+                    "The list of Categories associated with the App")
+
+          :suggested_categories
+          (describe [AppDetailCategory]
+                    "The list of Categories the integrator wishes to associate with the App")}))
+
+(defschema AppDocumentation
+  {(optional-key :app_id)
+   StringAppIdParam
+
+   :documentation
+   AppDocParam
+
+   :references
+   AppReferencesParam
+
+   (optional-key :created_on)
+   (describe Date "The Date the App's documentation was created")
+
+   (optional-key :modified_on)
+   (describe Date "The Date the App's documentation was last modified")
+
+   (optional-key :created_by)
+   (describe String "The user that created the App's documentation")
+
+   (optional-key :modified_by)
+   (describe String "The user that last modified the App's documentation")})
+
+(defschema AppDocumentationRequest
+  (dissoc AppDocumentation :references))
 
 (defschema PipelineEligibility
   {:is_valid (describe Boolean "Whether the App can be used in a Pipeline")
@@ -153,6 +470,75 @@
     {:app_ids                              (describe [QualifiedAppId] "A List of qualified app identifiers")
      (optional-key :root_deletion_request) (describe Boolean "Set to `true` to  delete one or more public apps")}
     "List of App IDs to delete."))
+
+(defschema AppParameterListItemRequest
+  (->optional-param AppParameterListItem :id))
+
+(defschema AppParameterListGroupRequest
+  (-> AppParameterListGroup
+      (->optional-param :id)
+      (assoc OptionalParameterArgumentsKey
+             (describe [AppParameterListItemRequest] TreeSelectorGroupParameterListDocs)
+             OptionalGroupsKey
+             (describe [(recursive #'AppParameterListGroupRequest)] TreeSelectorGroupGroupListDocs))))
+
+(defschema AppParameterListItemOrTreeRequest
+  (-> AppParameterListItemOrTree
+      (->optional-param :id)
+      (assoc OptionalParameterArgumentsKey
+             (describe [AppParameterListItemRequest] TreeSelectorParameterListDocs))
+      (assoc OptionalGroupsKey
+             (describe [AppParameterListGroupRequest] TreeSelectorGroupListDocs))))
+
+(defschema AppParameterRequest
+  (-> AppParameter
+      (->optional-param :id)
+      (assoc OptionalParameterArgumentsKey
+             (describe [AppParameterListItemOrTreeRequest] ListItemOrTreeDocs))))
+
+(defschema AppGroupRequest
+  (-> AppGroup
+      (->optional-param :id)
+      (assoc OptionalParametersKey (describe [AppParameterRequest] ParameterListDocs))))
+
+(defschema AppToolRequest
+  (-> ToolListingItem
+      (->optional-param :is_public)
+      (->optional-param :permission)
+      (->optional-param :implementation)
+      (->optional-param :container)
+      (assoc OptionalDeprecatedKey ToolDeprecatedParam)))
+
+(defschema AppRequest
+  (-> App
+      (->optional-param :id)
+      (assoc OptionalGroupsKey (describe [AppGroupRequest] GroupListDocs)
+             OptionalToolsKey  (describe [AppToolRequest] ToolListDocs))))
+
+(defschema AppPreviewRequest
+  (-> App
+      (->optional-param :id)
+      (->optional-param :name)
+      (->optional-param :description)
+      (assoc OptionalGroupsKey (describe [AppGroupRequest] GroupListDocs)
+             (optional-key :is_public) AppPublicParam
+             OptionalToolsKey  (describe [AppToolRequest] ToolListDocs))))
+
+(defschema AppCategoryMetadata
+  {(optional-key :avus) (describe [Any] "A listing of App Category metadata")})
+
+(defschema PublishAppRequest
+  (-> AppBase
+      (->optional-param :id)
+      (->optional-param :name)
+      (->optional-param :description)
+      (assoc (optional-key :documentation) AppDocParam
+             (optional-key :references) AppReferencesParam)
+      (merge AppCategoryMetadata)))
+
+(defschema AppPublishableResponse
+  {:publishable           (describe Boolean "True if the app is publishable.")
+   (optional-key :reason) (describe String "The reason the app can't be published if it's not publishable.")})
 
 (defschema FileMetadata
   {:attr  (describe String "The attribute name.")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -63,6 +63,12 @@
 
 (def AppListingSummary "List Apps")
 
+(def AppPublishableSummary "Determine if an App Can be Made Public")
+(def AppPublishableDocs
+  "A multi-step App can't be made public if any of the Tasks that are included in it are not public.
+   This endpoint returns a true flag if the App is a single-step App
+   or it's a multistep App in which all of the Tasks included in the pipeline are public.")
+
 (def AppPreviewSummary "Preview Command Line Arguments")
 (def AppPreviewDocs
   "The app integration utility in the DE uses this service to obtain an example list of command-line arguments

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -77,6 +77,13 @@
    The response body is in the same format as the `/arg-preview` service in the JEX.
    Please see the JEX documentation for more information.")
 
+(def AppRatingSummary "Rate an App")
+(def AppRatingDocs
+  "Users have the ability to rate an App for its usefulness, and this service provides the means to store the App rating.
+   This service accepts a rating level between one and five, inclusive,
+   and a comment identifier that refers to a comment in iPlant's Confluence wiki.
+   The rating is stored in the database and associated with the authenticated user.")
+
 (def AppRatingDeleteSummary "Delete an App Rating")
 (def AppRatingDeleteDocs
   "The DE uses this service to remove a rating that a user has previously made.

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -32,6 +32,8 @@
   "This service allows the Discovery Environment user interface to obtain an app description
    that can be used to construct a job submission form.")
 
+(def AppLabelUpdateSummary "Update App Labels")
+
 (def AppListingSummary "List Apps")
 
 (def AppPreviewSummary "Preview Command Line Arguments")
@@ -252,6 +254,8 @@
          {OptionalToolsKey           (describe [(merge Tool {OptionalDeprecatedKey ToolDeprecatedParam})] ToolListDocs)
           (optional-key :references) AppReferencesParam
           OptionalGroupsKey          (describe [AppGroup] GroupListDocs)}))
+
+(def AppLabelUpdateRequest (describe App "The App to update."))
 
 (defschema AppFileParameterDetails
   {:id          (describe String "The Parameter's ID")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -32,6 +32,9 @@
 
 (def AppDetailsSummary "Get App Details")
 
+(def AppDocumentationSummary "Get App Documentation")
+(def AppDocumentationDocs "This service is used by the DE to obtain documentation for a single App.")
+
 (def AppJobViewSummary "Obtain an app description.")
 (def AppJobViewDocs
   "This service allows the Discovery Environment user interface to obtain an app description

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -35,6 +35,9 @@
 (def AppDocumentationSummary "Get App Documentation")
 (def AppDocumentationDocs "This service is used by the DE to obtain documentation for a single App.")
 
+(def AppDocumentationAddSummary "Add App Documentation")
+(def AppDocumentationAddDocs "This service is used by the DE to add documentation for a single App.")
+
 (def AppDocumentationUpdateSummary "Update App Documentation")
 (def AppDocumentationUpdateDocs "This service is used by the DE to update documentation for a single App.")
 

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -95,6 +95,12 @@
    **Note**: an attempt to delete an app that is already marked as deleted is treated as a no-op rather than an error condition.
    If the App doesn't exist in the database at all, however, then that is treated as an error condition.")
 
+(def AppTaskListingSummary "List Tasks with File Parameters in an App")
+(def AppTaskListingDocs
+  "When a pipeline is being created, the UI needs to know what types of files are consumed by
+   and what types of files are produced by each App's task in the pipeline.
+   This service provides that information.")
+
 (def AppUpdateSummary "Update an App")
 
 (def PublishAppSummary "Submit an App for Public Use")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -101,6 +101,11 @@
    and what types of files are produced by each App's task in the pipeline.
    This service provides that information.")
 
+(def AppToolListingSummary "List Tools used by an App")
+(def AppToolListingDocs
+  "This service lists information for all of the tools that are associated with an App.
+   This information used to be included in the results of the App listing service.")
+
 (def AppUpdateSummary "Update an App")
 
 (def PublishAppSummary "Submit an App for Public Use")
@@ -420,6 +425,9 @@
           :suggested_categories
           (describe [AppDetailCategory]
                     "The list of Categories the integrator wishes to associate with the App")}))
+
+(defschema AppToolListing
+  {:tools (describe [AppDetailsTool] "Listing of App Tools")})
 
 (defschema AppDocumentation
   {(optional-key :app_id)

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -18,6 +18,9 @@
   (:require [clojure.set :as sets])
   (:import [java.util UUID Date]))
 
+(def AppCopySummary "Make a Copy of an App Available for Editing")
+(def AppCopyDocs "This service can be used to make a copy of an App in the user's workspace.")
+
 (def AppCreateSummary "Add a new App.")
 (def AppCreateDocs "This service adds a new App to the user's workspace.")
 

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -41,6 +41,11 @@
 (def AppDocumentationUpdateSummary "Update App Documentation")
 (def AppDocumentationUpdateDocs "This service is used by the DE to update documentation for a single App.")
 
+(def AppFavoriteDeleteSummary "Removing an App as a Favorite")
+(def AppFavoriteDeleteDocs
+  "Apps can be marked as favorites in the DE, which allows users to access them without having to search.
+   This service is used to remove an App from a user's favorites list.")
+
 (def AppJobViewSummary "Obtain an app description.")
 (def AppJobViewDocs
   "This service allows the Discovery Environment user interface to obtain an app description

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -18,6 +18,9 @@
   (:require [clojure.set :as sets])
   (:import [java.util UUID Date]))
 
+(def AppCreateSummary "Add a new App.")
+(def AppCreateDocs "This service adds a new App to the user's workspace.")
+
 (def AppListingSummary "List Apps")
 
 (def AppsShredderSummary "Logically Deleting Apps")
@@ -514,6 +517,8 @@
       (->optional-param :id)
       (assoc OptionalGroupsKey (describe [AppGroupRequest] GroupListDocs)
              OptionalToolsKey  (describe [AppToolRequest] ToolListDocs))))
+
+(def AppCreateRequest (describe AppRequest "The App to add."))
 
 (defschema AppPreviewRequest
   (-> App

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -85,6 +85,13 @@
 
 (def AppUpdateSummary "Update an App")
 
+(def PublishAppSummary "Submit an App for Public Use")
+(def PublishAppDocs
+  "This service can be used to submit a private App for public use.
+   The user supplies basic information about the App and a suggested location for it.
+   The service records the information and suggested location then places the App in the Beta category.
+   A Tito administrator can subsequently move the App to the suggested location at a later time if it proves to be useful.")
+
 (def AppCategoryIdPathParam (describe UUID "The App Category's UUID"))
 (def AppDeletedParam (describe Boolean "Whether the App is marked as deleted"))
 (def AppDisabledParam (describe Boolean "Whether the App is marked as disabled"))
@@ -601,7 +608,8 @@
       (->optional-param :description)
       (assoc (optional-key :documentation) AppDocParam
              (optional-key :references) AppReferencesParam)
-      (merge AppCategoryMetadata)))
+      (merge AppCategoryMetadata)
+      (describe "The user's Publish App Request.")))
 
 (defschema AppPublishableResponse
   {:publishable           (describe Boolean "True if the app is publishable.")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -77,6 +77,11 @@
    The response body is in the same format as the `/arg-preview` service in the JEX.
    Please see the JEX documentation for more information.")
 
+(def AppRatingDeleteSummary "Delete an App Rating")
+(def AppRatingDeleteDocs
+  "The DE uses this service to remove a rating that a user has previously made.
+   This service deletes the authenticated user's rating for the corresponding app-id.")
+
 (def AppsShredderSummary "Logically Deleting Apps")
 (def AppsShredderDocs
   "One or more Apps can be marked as deleted in the DE without being completely removed from the database using this service.

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -41,6 +41,11 @@
 (def AppDocumentationUpdateSummary "Update App Documentation")
 (def AppDocumentationUpdateDocs "This service is used by the DE to update documentation for a single App.")
 
+(def AppEditingViewSummary "Make an App Available for Editing")
+(def AppEditingViewDocs
+  "The app integration utility in the DE uses this service to obtain the App description JSON so that it can be edited.
+   The App must have been integrated by the requesting user.")
+
 (def AppFavoriteAddSummary "Marking an App as a Favorite")
 (def AppFavoriteAddDocs
   "Apps can be marked as favorites in the DE, which allows users to access them without having to search.

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -41,6 +41,11 @@
 (def AppDocumentationUpdateSummary "Update App Documentation")
 (def AppDocumentationUpdateDocs "This service is used by the DE to update documentation for a single App.")
 
+(def AppFavoriteAddSummary "Marking an App as a Favorite")
+(def AppFavoriteAddDocs
+  "Apps can be marked as favorites in the DE, which allows users to access them without having to search.
+   This service is used to add an App to a user's favorites list.")
+
 (def AppFavoriteDeleteSummary "Removing an App as a Favorite")
 (def AppFavoriteDeleteDocs
   "Apps can be marked as favorites in the DE, which allows users to access them without having to search.

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -23,6 +23,14 @@
 
 (def AppListingSummary "List Apps")
 
+(def AppPreviewSummary "Preview Command Line Arguments")
+(def AppPreviewDocs
+  "The app integration utility in the DE uses this service to obtain an example list of command-line arguments
+   so that the user can tell what the command-line might look like without having to run a job using the app that is being integrated first.
+   The App request body also requires that each parameter contain a `value` field that contains the parameter value to include on the command line.
+   The response body is in the same format as the `/arg-preview` service in the JEX.
+   Please see the JEX documentation for more information.")
+
 (def AppsShredderSummary "Logically Deleting Apps")
 (def AppsShredderDocs
   "One or more Apps can be marked as deleted in the DE without being completely removed from the database using this service.
@@ -527,7 +535,8 @@
       (->optional-param :description)
       (assoc OptionalGroupsKey (describe [AppGroupRequest] GroupListDocs)
              (optional-key :is_public) AppPublicParam
-             OptionalToolsKey  (describe [AppToolRequest] ToolListDocs))))
+             OptionalToolsKey (describe [AppToolRequest] ToolListDocs))
+      (describe "The App to preview.")))
 
 (defschema AppCategoryMetadata
   {(optional-key :avus) (describe [Any] "A listing of App Category metadata")})

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -21,6 +21,12 @@
 (def AppCreateSummary "Add a new App.")
 (def AppCreateDocs "This service adds a new App to the user's workspace.")
 
+(def AppDeleteSummary "Logically Deleting an App")
+(def AppDeleteDocs
+  "An app can be marked as deleted in the DE without being completely removed from the database using this service.
+   **Note**: an attempt to delete an App that is already marked as deleted is treated as a no-op rather than an error condition.
+   If the App doesn't exist in the database at all, however, then that is treated as an error condition.")
+
 (def AppJobViewSummary "Obtain an app description.")
 (def AppJobViewDocs
   "This service allows the Discovery Environment user interface to obtain an app description
@@ -39,7 +45,7 @@
 (def AppsShredderSummary "Logically Deleting Apps")
 (def AppsShredderDocs
   "One or more Apps can be marked as deleted in the DE without being completely removed from the database using this service.
-   <b>Note</b>: an attempt to delete an app that is already marked as deleted is treated as a no-op rather than an error condition.
+   **Note**: an attempt to delete an app that is already marked as deleted is treated as a no-op rather than an error condition.
    If the App doesn't exist in the database at all, however, then that is treated as an error condition.")
 
 (def AppCategoryIdPathParam (describe UUID "The App Category's UUID"))

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -35,6 +35,9 @@
 (def AppDocumentationSummary "Get App Documentation")
 (def AppDocumentationDocs "This service is used by the DE to obtain documentation for a single App.")
 
+(def AppDocumentationUpdateSummary "Update App Documentation")
+(def AppDocumentationUpdateDocs "This service is used by the DE to update documentation for a single App.")
+
 (def AppJobViewSummary "Obtain an app description.")
 (def AppJobViewDocs
   "This service allows the Discovery Environment user interface to obtain an app description
@@ -394,7 +397,9 @@
    (describe String "The user that last modified the App's documentation")})
 
 (defschema AppDocumentationRequest
-  (dissoc AppDocumentation :references))
+  (-> AppDocumentation
+      (dissoc :references)
+      (describe "The App Documentation Request")))
 
 (defschema PipelineEligibility
   {:is_valid (describe Boolean "Whether the App can be used in a Pipeline")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -51,6 +51,9 @@
   "Apps can be marked as favorites in the DE, which allows users to access them without having to search.
    This service is used to remove an App from a user's favorites list.")
 
+(def AppIntegrationDataSummary "Return the Integration Data Record for an App")
+(def AppIntegrationDataDocs "This service returns the integration data associated with an app.")
+
 (def AppJobViewSummary "Obtain an app description.")
 (def AppJobViewDocs
   "This service allows the Discovery Environment user interface to obtain an app description

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -21,6 +21,11 @@
 (def AppCreateSummary "Add a new App.")
 (def AppCreateDocs "This service adds a new App to the user's workspace.")
 
+(def AppJobViewSummary "Obtain an app description.")
+(def AppJobViewDocs
+  "This service allows the Discovery Environment user interface to obtain an app description
+   that can be used to construct a job submission form.")
+
 (def AppListingSummary "List Apps")
 
 (def AppPreviewSummary "Preview Command Line Arguments")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -50,6 +50,8 @@
    **Note**: an attempt to delete an app that is already marked as deleted is treated as a no-op rather than an error condition.
    If the App doesn't exist in the database at all, however, then that is treated as an error condition.")
 
+(def AppUpdateSummary "Update an App")
+
 (def AppCategoryIdPathParam (describe UUID "The App Category's UUID"))
 (def AppDeletedParam (describe Boolean "Whether the App is marked as deleted"))
 (def AppDisabledParam (describe Boolean "Whether the App is marked as disabled"))
@@ -542,6 +544,7 @@
              OptionalToolsKey  (describe [AppToolRequest] ToolListDocs))))
 
 (def AppCreateRequest (describe AppRequest "The App to add."))
+(def AppUpdateRequest (describe AppRequest "The App to update."))
 
 (defschema AppPreviewRequest
   (-> App

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -30,6 +30,8 @@
    **Note**: an attempt to delete an App that is already marked as deleted is treated as a no-op rather than an error condition.
    If the App doesn't exist in the database at all, however, then that is treated as an error condition.")
 
+(def AppDetailsSummary "Get App Details")
+
 (def AppJobViewSummary "Obtain an app description.")
 (def AppJobViewDocs
   "This service allows the Discovery Environment user interface to obtain an app description

--- a/src/common_swagger_api/schema/apps/rating.clj
+++ b/src/common_swagger_api/schema/apps/rating.clj
@@ -15,5 +15,6 @@
      (optional-key :comment_id) CommentIdParam}))
 
 (defschema RatingRequest
-  {:rating                    UserRatingParam
-   (optional-key :comment_id) CommentIdParam})
+  (-> {:rating                    UserRatingParam
+       (optional-key :comment_id) CommentIdParam}
+      (describe "The user's new rating for this App.")))

--- a/src/common_swagger_api/schema/containers.clj
+++ b/src/common_swagger_api/schema/containers.clj
@@ -1,0 +1,86 @@
+(ns common-swagger-api.schema.containers
+  (:use [common-swagger-api.schema :only [->optional-param describe]])
+  (:require [schema.core :as s]))
+
+(s/defschema Image
+  (-> {:name                            s/Str
+       :id                              s/Uuid
+       (s/optional-key :tag)            s/Str
+       (s/optional-key :url)            (s/maybe s/Str)
+       (s/optional-key :deprecated)     Boolean
+       (s/optional-key :auth)           (s/maybe s/Str)
+       (s/optional-key :osg_image_path) (s/maybe s/Str)}
+      (describe "A map describing a container image.")))
+
+(s/defschema Settings
+  (-> {(s/optional-key :cpu_shares)        (describe Integer "The shares of the CPU that the tool container will receive")
+       (s/optional-key :pids_limit)        Integer
+       (s/optional-key :memory_limit)      (describe Long "The amount of memory (in bytes) that the tool container is restricted to")
+       (s/optional-key :min_memory_limit)  (describe Long "The minimum about of memory (in bytes) that is required to run the tool container")
+       (s/optional-key :min_cpu_cores)     (describe Double "The minimum number of CPU cores needed to run the tool container")
+       (s/optional-key :max_cpu_cores)     Double
+       (s/optional-key :min_disk_space)    (describe Long "The minimum amount of disk space needed to run the tool container")
+       (s/optional-key :network_mode)      (describe s/Str "The network mode for the tool container")
+       (s/optional-key :working_directory) (describe s/Str "The working directory in the tool container")
+       (s/optional-key :name)              (describe s/Str "The name given to the tool container")
+       (s/optional-key :entrypoint)        (describe s/Str "The entrypoint for a tool container")
+       (s/optional-key :skip_tmp_mount)    Boolean
+       (s/optional-key :uid)               Integer
+       :id                                 s/Uuid}
+      (describe "The group of settings for a container.")))
+
+(s/defschema Device
+  (-> {:host_path      (describe s/Str "A device's path on the container host")
+       :container_path (describe s/Str "A device's path inside the tool container")
+       :id             s/Uuid}
+      (describe "Information about a device associated with a tool's container.")))
+
+(s/defschema Volume
+  (-> {:host_path      (describe s/Str "The path to a bind mounted volume on the host machine")
+       :container_path (describe s/Str "The path to a bind mounted volume in the tool container")
+       :id             s/Uuid}
+      (describe "A map representing a bind mounted container volume.")))
+
+(s/defschema DataContainer
+  (-> (merge (dissoc Image :id)
+             {:id                         s/Uuid
+              :name_prefix                s/Str
+              (s/optional-key :read_only) s/Bool})
+      (describe "A description of a data container.")))
+
+(s/defschema VolumesFrom
+  (describe DataContainer "A description of a data container volumes-from settings."))
+
+(s/defschema Port
+  (-> {:id                            s/Uuid
+       (s/optional-key :host_port)    (s/maybe Integer)
+       :container_port                Integer
+       (s/optional-key :bind_to_host) (s/maybe Boolean)}
+      (describe "Port information for a tool container.")))
+
+(s/defschema ProxySettings
+  (-> {:id                             s/Uuid
+       :image                          String
+       :name                           String
+       (s/optional-key :frontend_url)  (s/maybe String)
+       (s/optional-key :cas_url)       (s/maybe String)
+       (s/optional-key :cas_validate)  (s/maybe String)
+       (s/optional-key :ssl_cert_path) (s/maybe String)
+       (s/optional-key :ssl_key_path)  (s/maybe String)}
+      (describe "Interactive app settings for the reverse proxy that runs on the HTCondor nodes for each job.")))
+
+(def DevicesParamOptional       (s/optional-key :container_devices))
+(def VolumesParamOptional       (s/optional-key :container_volumes))
+(def VolumesFromParamOptional   (s/optional-key :container_volumes_from))
+(def PortsParamOptional         (s/optional-key :container_ports))
+(def ProxySettingsParamOptional (s/optional-key :interactive_apps))
+
+(s/defschema ToolContainer
+  (-> (merge Settings
+             {DevicesParamOptional       (describe [Device] "A list of devices associated with a tool's container")
+              VolumesParamOptional       (describe [Volume] "A list of Volumes associated with a tool's container")
+              VolumesFromParamOptional   (describe [VolumesFrom] "The list of VolumeFroms associated with a tool's container.")
+              PortsParamOptional         [Port]
+              ProxySettingsParamOptional ProxySettings
+              :image                     Image})
+      (describe "All container and container image information associated with a tool.")))

--- a/src/common_swagger_api/schema/integration_data.clj
+++ b/src/common_swagger_api/schema/integration_data.clj
@@ -1,0 +1,27 @@
+(ns common-swagger-api.schema.integration-data
+  (:use [common-swagger-api.schema :only [describe NonBlankString]]
+        [schema.core :only [defschema optional-key]])
+  (:import [java.util UUID]))
+
+(defschema IntegrationDataUpdate
+  {:email
+   (describe NonBlankString "The user's email address.")
+
+   :name
+   (describe NonBlankString "The user's name.")})
+
+(defschema IntegrationDataRequest
+  (assoc IntegrationDataUpdate
+         (optional-key :username)
+         (describe NonBlankString "The username associated with the integration data entry.")))
+
+(defschema IntegrationData
+  (assoc IntegrationDataRequest
+         :id (describe UUID "The integration data identifier.")))
+
+(defschema IntegrationDataListing
+  {:integration_data
+   (describe [IntegrationData] "The list of integration data entries.")
+
+   :total
+   (describe Long "The total number of matching integration data entries.")})

--- a/src/common_swagger_api/schema/tools.clj
+++ b/src/common_swagger_api/schema/tools.clj
@@ -1,0 +1,75 @@
+(ns common-swagger-api.schema.tools
+  (:use [common-swagger-api.schema :only [->optional-param describe]]
+        [common-swagger-api.schema.containers :only [Image
+                                                     Settings
+                                                     ToolContainer]]
+        [schema.core :only [defschema enum optional-key]])
+  (:require [schema.core :as s])
+  (:import (java.util UUID)))
+
+(def ToolIdParam (describe UUID "A UUID that is used to identify the Tool"))
+(def ToolRequestIdParam (describe UUID "The Tool Requests's UUID"))
+(def ToolRequestToolIdParam (describe UUID "The ID of the tool the user is requesting to be made public"))
+(def ToolNameParam (describe String "The Tool's name (can be the file name or Docker image)"))
+(def ToolDescriptionParam (describe String "A brief description of the Tool"))
+(def VersionParam (describe String "The Tool's version"))
+(def AttributionParam (describe String "The Tool's author or publisher"))
+(def SubmittedByParam (describe String "The username of the user that submitted the Tool Request"))
+(def ToolImplementationDocs "Information about the user who integrated the Tool into the DE")
+(def Interactive (describe Boolean "Determines whether the tool is interactive."))
+
+(defschema ToolTestData
+  {(optional-key :params) (describe [String] "The list of command-line parameters")
+   :input_files           (describe [String] "The list of paths to test input files in iRODS")
+   :output_files          (describe [String] "The list of paths to expected output files in iRODS")})
+
+(defschema ToolImplementor
+  {:implementor       (describe String "The name of the implementor")
+   :implementor_email (describe String "The email address of the implementor")})
+
+(defschema ToolImplementation
+  (merge ToolImplementor
+         {:test (describe ToolTestData "The test data for the Tool")}))
+
+(defschema Tool
+  {:id                                ToolIdParam
+   :name                              ToolNameParam
+   (optional-key :description)        ToolDescriptionParam
+   (optional-key :attribution)        AttributionParam
+   (optional-key :location)           (describe String "The path of the directory containing the Tool")
+   :version                           VersionParam
+   :type                              (describe String "The Tool Type name")
+   (optional-key :restricted)         (describe Boolean "Determines whether a time limit is applied and whether network access is granted")
+   (optional-key :time_limit_seconds) (describe Integer "The number of seconds that a tool is allowed to execute. A value of 0 means the time limit is disabled")
+   (optional-key :interactive)        Interactive})
+
+(defschema ToolDetails
+  (merge Tool
+         {:is_public      (describe Boolean "Whether the Tool has been published and is viewable by all users")
+          :permission     (describe String "The user's access level for the Tool")
+          :implementation (describe ToolImplementation ToolImplementationDocs)
+          :container      ToolContainer}))
+
+(defschema ToolListingImage
+  (assoc (dissoc Settings :id)
+    :image (dissoc Image :id)))
+
+(defschema ToolRequestSummary
+  {:id                     ToolRequestIdParam
+   :name                   ToolNameParam
+   :version                VersionParam
+   :requested_by           SubmittedByParam
+   (optional-key :tool_id) ToolRequestToolIdParam
+   :date_submitted         (describe Long "The timestamp of the Tool Request submission")
+   :status                 (describe String "The current status of the Tool Request")
+   :date_updated           (describe Long "The timestamp of the last Tool Request status update")
+   :updated_by             (describe String "The username of the user that last updated the Tool Request status")})
+
+(defschema ToolListingToolRequestSummary
+  (select-keys ToolRequestSummary [:id :status]))
+
+(defschema ToolListingItem
+  (merge ToolDetails
+         {:implementation              (describe ToolImplementor ToolImplementationDocs)
+          :container                   ToolListingImage
+          (optional-key :tool_request) ToolListingToolRequestSummary}))


### PR DESCRIPTION
This PR will migrate the non-admin schemas from `apps.routes.schemas.app` and the endpoint docs from `apps.routes.apps` to `common-swagger-api.schema.apps`.

This requires migrating schemas from the following namespaces:
*  from `apps.routes.schemas.containers` to `common-swagger-api.schema.containers`
* from `apps.routes.schemas.tool` to `common-swagger-api.schema.tools`
* from `apps.routes.schemas.integration-data` to `common-swagger-api.schema.integration-data`

It might be easier to review this PR one commit at a time. Or (as I've done with similar PRs), open this PR in one tab and cyverse-de/apps#154 in another, then swap back and forth between tabs as a kind of [blink comparator](https://en.wikipedia.org/wiki/Blink_comparator).