### PR TITLE
CORE-11 Import /apps/hierarchies docs and schemas

### DIFF
--- a/resources/docs/apps/categories/category-hierarchy-listing.md
+++ b/resources/docs/apps/categories/category-hierarchy-listing.md
@@ -1,0 +1,6 @@
+Gets the list of app categories that are visible to the user for the active ontology version,
+rooted at the given `root-iri`.
+
+#### Delegates to metadata service
+    POST /ontologies/{ontology-version}/{root-iri}/filter
+Please see the metadata service documentation for response information.

--- a/resources/docs/apps/categories/hierarchies-listing.md
+++ b/resources/docs/apps/categories/hierarchies-listing.md
@@ -1,0 +1,5 @@
+Lists all hierarchies saved for the active ontology version.
+
+#### Delegates to metadata service
+    GET /ontologies/{ontology-version}
+Please see the metadata service documentation for response information.

--- a/resources/docs/apps/categories/hierarchy-app-listing.md
+++ b/resources/docs/apps/categories/hierarchy-app-listing.md
@@ -1,0 +1,4 @@
+Lists all of the apps under an app category hierarchy that are visible to the user.
+
+#### Delegates to metadata service
+    POST /ontologies/{ontology-version}/{root-iri}/filter-targets

--- a/resources/docs/apps/categories/hierarchy-unclassified-app-listing.md
+++ b/resources/docs/apps/categories/hierarchy-unclassified-app-listing.md
@@ -1,0 +1,4 @@
+Lists all of the apps that are visible to the user that are not under the given app category or any of its subcategories.
+
+#### Delegates to metadata service
+    POST /ontologies/{ontology-version}/{root-iri}/filter-unclassified

--- a/src/common_swagger_api/schema/apps/categories.clj
+++ b/src/common_swagger_api/schema/apps/categories.clj
@@ -17,6 +17,10 @@
    The DE uses this service to obtain the list of apps when a user clicks on a category in the _Apps_ window.
    This endpoint accepts optional URL query parameters to limit and sort Apps, which will allow pagination of results.")
 
+(def AppCategoryHierarchyListingSummary "List App Category Hierarchy")
+(def AppHierarchiesListingSummary "List App Hierarchies")
+(def AppHierarchyUnclassifiedListingSummary "List Unclassified Apps")
+
 (def AppCategoryNameParam (describe String "The App Category's name"))
 
 (defschema CategoryListingParams

--- a/src/common_swagger_api/schema/apps/categories.clj
+++ b/src/common_swagger_api/schema/apps/categories.clj
@@ -1,6 +1,11 @@
 (ns common-swagger-api.schema.apps.categories
   (:use [common-swagger-api.schema :only [describe]]
-        [common-swagger-api.schema.apps :only [AppCategoryIdPathParam AppListingDetail SystemId]]
+        [common-swagger-api.schema.apps
+         :only [AppCategoryIdPathParam
+                AppListingDetail
+                AppListingPagingParams
+                SystemId]]
+        [common-swagger-api.schema.ontologies :only [OntologyHierarchyFilterParams]]
         [schema.core :only [defschema optional-key recursive]]))
 
 (def AppCategoryListingSummary "List App Categories")
@@ -51,3 +56,7 @@
 (defschema AppCategoryAppListing
   (merge (dissoc AppCategory :categories)
          {:apps (describe [AppListingDetail] "A listing of Apps under this Category")}))
+
+(defschema OntologyAppListingPagingParams
+  (merge AppListingPagingParams
+         OntologyHierarchyFilterParams))

--- a/src/common_swagger_api/schema/ontologies.clj
+++ b/src/common_swagger_api/schema/ontologies.clj
@@ -6,6 +6,9 @@
 (def OntologyVersionParam (describe String "The unique version of the Ontology"))
 (def OntologyClassIRIParam (describe String "A unique Class IRI"))
 
+(s/defschema OntologyHierarchyFilterParams
+  {:attr (describe String "The metadata attribute that stores class IRIs under the given root IRI")})
+
 (s/defschema OntologyDetails
   {:iri        (describe (s/maybe String) "The unique IRI for this Ontology")
    :version    OntologyVersionParam


### PR DESCRIPTION
This PR will import more docs and schemas from `apps.routes.schemas.app.category` and `apps.routes.apps.categories`.