### PR TITLE
CORE-11 Remove `Delegates to metadata service` sections from apps docs

### DIFF
--- a/resources/docs/apps/app-details.md
+++ b/resources/docs/apps/app-details.md
@@ -1,5 +1,0 @@
-This service is used by the DE to obtain high-level details about a single App.
-
-#### Delegates to metadata service
-    POST /ontologies/{ontology-version}/filter
-Please see the metadata service documentation for information about the `hierarchies` response field.

--- a/resources/docs/apps/app-label-update.md
+++ b/resources/docs/apps/app-label-update.md
@@ -9,8 +9,3 @@ Upon error, the response body contains an error code along with some additional 
 only the `name` (except in parameters and parameter arguments),
 `description`, `label`, and `display` (only in parameter arguments)
 fields will be processed and updated by this endpoint.
-
-#### Delegates to metadata service
-    POST /avus/filter-targets
-    GET /avus/{target-type}/{target-id}
-Where `{target-type}` is `app`.

--- a/resources/docs/apps/app-update.md
+++ b/resources/docs/apps/app-update.md
@@ -1,8 +1,0 @@
-This service updates a single-step App in the database, as long as the App has not been submitted for public use,
-and the app's name must not duplicate the name of any other app (visible to the requesting user)
-under the same categories as this app.
-
-#### Delegates to metadata service
-    POST /avus/filter-targets
-    GET /avus/{target-type}/{target-id}
-Where `{target-type}` is `app`.

--- a/resources/docs/apps/apps-listing.md
+++ b/resources/docs/apps/apps-listing.md
@@ -1,9 +1,0 @@
-This service allows users to get a paged listing of all Apps accessible to the user.
-If the `search` parameter is included, then the results are filtered by
-the App name, description, integrator's name, tool name, or category name the app is under.
-
-#### Delegates to metadata service
-    POST /avus/filter-targets
-
-#### Delegates to metadata service
-    POST /ontologies/{ontology-version}/filter-targets

--- a/resources/docs/apps/categories/category-hierarchy-listing.md
+++ b/resources/docs/apps/categories/category-hierarchy-listing.md
@@ -1,6 +1,0 @@
-Gets the list of app categories that are visible to the user for the active ontology version,
-rooted at the given `root-iri`.
-
-#### Delegates to metadata service
-    POST /ontologies/{ontology-version}/{root-iri}/filter
-Please see the metadata service documentation for response information.

--- a/resources/docs/apps/categories/hierarchies-listing.md
+++ b/resources/docs/apps/categories/hierarchies-listing.md
@@ -1,5 +1,0 @@
-Lists all hierarchies saved for the active ontology version.
-
-#### Delegates to metadata service
-    GET /ontologies/{ontology-version}
-Please see the metadata service documentation for response information.

--- a/resources/docs/apps/categories/hierarchy-app-listing.md
+++ b/resources/docs/apps/categories/hierarchy-app-listing.md
@@ -1,4 +1,0 @@
-Lists all of the apps under an app category hierarchy that are visible to the user.
-
-#### Delegates to metadata service
-    POST /ontologies/{ontology-version}/{root-iri}/filter-targets

--- a/resources/docs/apps/categories/hierarchy-unclassified-app-listing.md
+++ b/resources/docs/apps/categories/hierarchy-unclassified-app-listing.md
@@ -1,4 +1,0 @@
-Lists all of the apps that are visible to the user that are not under the given app category or any of its subcategories.
-
-#### Delegates to metadata service
-    POST /ontologies/{ontology-version}/{root-iri}/filter-unclassified

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -7,6 +7,7 @@
                                           SortFieldDocs
                                           SortFieldOptionalKey]]
         [common-swagger-api.schema.apps.rating :only [Rating]]
+        [common-swagger-api.schema.ontologies :only [OntologyHierarchyList]]
         [common-swagger-api.schema.tools :only [Tool ToolDetails ToolListingImage ToolListingItem]]
         [schema.core :only [defschema
                             enum
@@ -31,6 +32,8 @@
    If the App doesn't exist in the database at all, however, then that is treated as an error condition.")
 
 (def AppDetailsSummary "Get App Details")
+(def AppDetailsDocs
+  "This service is used by the DE to obtain high-level details about a single App.")
 
 (def AppDocumentationSummary "Get App Documentation")
 (def AppDocumentationDocs "This service is used by the DE to obtain documentation for a single App.")
@@ -67,6 +70,10 @@
 (def AppLabelUpdateSummary "Update App Labels")
 
 (def AppListingSummary "List Apps")
+(def AppListingDocs
+  "This service allows users to get a paged listing of all Apps accessible to the user.
+   If the `search` parameter is included, then the results are filtered by
+   the App name, description, integrator's name, tool name, or category name the app is under.")
 
 (def AppPublishableSummary "Determine if an App Can be Made Public")
 (def AppPublishableDocs
@@ -112,6 +119,10 @@
    This information used to be included in the results of the App listing service.")
 
 (def AppUpdateSummary "Update an App")
+(def AppUpdateDocs
+  "This service updates a single-step App in the database, as long as the App has not been submitted for public use,
+   and the app's name must not duplicate the name of any other app (visible to the requesting user)
+   under the same categories as this app.")
 
 (def PublishAppSummary "Submit an App for Public Use")
 (def PublishAppDocs
@@ -391,45 +402,26 @@
    (describe Date "The last date this app has run to `Completed` status")})
 
 (defschema AppDetails
-  (merge AppBase
-         {:id
-          (describe String "The app identifier.")
-
-          :tools
-          (describe [AppDetailsTool] ToolListDocs)
-
-          :deleted
-          AppDeletedParam
-
-          :disabled
-          AppDisabledParam
-
-          :integrator_email
-          (describe String "The App integrator's email address.")
-
-          :integrator_name
-          (describe String "The App integrator's full name.")
-
-          (optional-key :wiki_url)
-          AppDocUrlParam
-
-          :references
-          AppReferencesParam
-
-          (optional-key :job_stats)
-          (describe AppListingJobStats AppListingJobStatsDocs)
-
-          (optional-key :hierarchies)
-          (describe Any
-                    "The ontology hierarchies associated with the App")
-
-          :categories
-          (describe [AppDetailCategory]
-                    "The list of Categories associated with the App")
-
-          :suggested_categories
-          (describe [AppDetailCategory]
-                    "The list of Categories the integrator wishes to associate with the App")}))
+  (-> AppBase
+      (merge {:id                   (describe String "The app identifier.")
+              :tools                (describe [AppDetailsTool] ToolListDocs)
+              :deleted              AppDeletedParam
+              :disabled             AppDisabledParam
+              :integrator_email     (describe String "The App integrator's email address.")
+              :integrator_name      (describe String "The App integrator's full name.")
+              :wiki_url             AppDocUrlParam
+              :references           AppReferencesParam
+              :job_stats            (describe AppListingJobStats AppListingJobStatsDocs)
+              :categories           (describe
+                                      [AppDetailCategory]
+                                      "The list of Categories associated with the App")
+              :suggested_categories (describe
+                                      [AppDetailCategory]
+                                      "The list of Categories the integrator wishes to associate with the App")}
+             OntologyHierarchyList)
+      (->optional-param :wiki_url)
+      (->optional-param :job_stats)
+      (->optional-param :hierarchies)))
 
 (defschema AppToolListing
   {:tools (describe [AppDetailsTool] "Listing of App Tools")})

--- a/src/common_swagger_api/schema/apps/categories.clj
+++ b/src/common_swagger_api/schema/apps/categories.clj
@@ -11,6 +11,7 @@
 (def AppCategoryListingSummary "List App Categories")
 (def AppCategoryListingDocs
   "This service is used by the DE to obtain the list of app categories that are visible to the user.")
+
 (def AppCategoryAppListingSummary "List Apps in a Category")
 (def AppCategoryAppListingDocs
   "This service lists all of the apps within an app category or any of its descendents.
@@ -18,8 +19,20 @@
    This endpoint accepts optional URL query parameters to limit and sort Apps, which will allow pagination of results.")
 
 (def AppCategoryHierarchyListingSummary "List App Category Hierarchy")
+(def AppCategoryHierarchyListingDocs
+  "Gets the list of app categories that are visible to the user for the active ontology version,
+   rooted at the given `root-iri`.")
+
 (def AppHierarchiesListingSummary "List App Hierarchies")
+(def AppHierarchiesListingDocs
+  "Lists all hierarchies saved for the active ontology version.")
+
+(def AppHierarchyAppListingDocs "Lists all of the apps under an app category hierarchy that are visible to the user.")
+
 (def AppHierarchyUnclassifiedListingSummary "List Unclassified Apps")
+(def AppHierarchyUnclassifiedListingDocs
+  "Lists all of the apps that are visible to the user that are not under the given app category
+   or any of its subcategories.")
 
 (def AppCategoryNameParam (describe String "The App Category's name"))
 

--- a/src/common_swagger_api/schema/ontologies.clj
+++ b/src/common_swagger_api/schema/ontologies.clj
@@ -14,3 +14,24 @@
    :version    OntologyVersionParam
    :created_by (describe NonBlankString "The user who uploaded this Ontology")
    :created_on (describe Date "The date this Ontology was uploaded")})
+
+(s/defschema OntologyClass
+  {:iri
+   (describe String "The unique IRI for this Ontology Class")
+
+   :label
+   (describe (s/maybe String) "The label annotation of this Ontology Class")
+
+   (s/optional-key :description)
+   (describe (s/maybe String) "The description annotation of this Ontology Class")})
+
+(s/defschema OntologyClassHierarchy
+  (merge OntologyClass
+         {(s/optional-key :subclasses)
+          (describe [(s/recursive #'OntologyClassHierarchy)] "Subclasses of this Ontology Class")}))
+
+(s/defschema OntologyHierarchy
+  {:hierarchy (describe (s/maybe OntologyClassHierarchy) "An Ontology Class hierarchy")})
+
+(s/defschema OntologyHierarchyList
+  {:hierarchies (describe [OntologyClassHierarchy] "A list of Ontology Class hierarchies")})


### PR DESCRIPTION
This PR will remove the `Delegates to metadata service` endpoint sections from apps endpoint docs.

Imported some metadata service response docs into `common-swagger-api.schema.ontologies` for use in the `apps` and `terrain` services.
Some markdown docs became small enough to be defined as strings instead.