### PR TITLE
CORE-11 Import /apps/{app-id}/metadata schemas and docs

### DIFF
--- a/src/common_swagger_api/schema/apps/metadata.clj
+++ b/src/common_swagger_api/schema/apps/metadata.clj
@@ -1,0 +1,20 @@
+(ns common-swagger-api.schema.apps.metadata)
+
+(def AppMetadataListingSummary "View all Metadata AVUs")
+(def AppMetadataListingDocs
+  "Lists all AVUs associated with an app.
+   The authenticated user must have `read` permission to view this metadata.")
+
+(def AppMetadataSetSummary "Set Metadata AVUs")
+(def AppMetadataSetDocs
+  "Sets Metadata AVUs on the app.
+   The authenticated user must have `write` permission to edit this metadata,
+   and the app's name must not duplicate the name of any other app (visible to the requesting user)
+   that also has any of the ontology hierarchy AVUs given in the request.")
+
+(def AppMetadataUpdateSummary "Add/Update Metadata AVUs")
+(def AppMetadataUpdateDocs
+  "Adds or updates Metadata AVUs on the app.
+   The authenticated user must have `write` permission to edit this metadata,
+   and the app's name must not duplicate the name of any other app (visible to the requesting user)
+   that also has any of the ontology hierarchy AVUs given in the request.")

--- a/src/common_swagger_api/schema/metadata.clj
+++ b/src/common_swagger_api/schema/metadata.clj
@@ -1,0 +1,41 @@
+(ns common-swagger-api.schema.metadata
+  (:use [common-swagger-api.schema :only [->optional-param describe]])
+  (:require [schema.core :as s])
+  (:import (java.util UUID)))
+
+(def TargetIdParam (describe UUID "The target item's UUID"))
+
+(s/defschema Avu
+  {:id                    (describe UUID "The AVU's UUID")
+   :attr                  (describe String "The Attribute's name")
+   :value                 (describe String "The Attribute's value")
+   :unit                  (describe String "The Attribute's unit")
+   :target_id             TargetIdParam
+   :created_by            (describe String "The ID of the user who created the AVU")
+   :modified_by           (describe String "The ID of the user who last modified the AVU")
+   :created_on            (describe Long "The date the AVU was created in ms since the POSIX epoch")
+   :modified_on           (describe Long "The date the AVU was last modified in ms since the POSIX epoch")
+   (s/optional-key :avus) (describe [(s/recursive #'Avu)] "AVUs attached to this AVU")})
+
+(s/defschema AvuList
+  {:avus (describe [Avu] "The list of AVUs")})
+
+(s/defschema AvuRequest
+  (-> Avu
+      (->optional-param :id)
+      (->optional-param :target_id)
+      (->optional-param :created_by)
+      (->optional-param :modified_by)
+      (->optional-param :created_on)
+      (->optional-param :modified_on)
+      (assoc (s/optional-key :avus)
+             (describe [(s/recursive #'AvuRequest)] "AVUs attached to this AVU"))))
+
+(s/defschema AvuListRequest
+  (-> {:avus (describe [AvuRequest] "The AVUs to save for the target data item")}
+      (describe "The Metadata AVU update request")))
+
+(s/defschema SetAvuRequest
+  (-> AvuListRequest
+      (->optional-param :avus)
+      (describe "The Metadata AVU save request")))


### PR DESCRIPTION
This PR will import some AVU schemas from `metadata.routes.schemas.avus` into `common-swagger-api.schema.metadata`, and docs for `/apps/{app-id}/metadata` endpoints into `common-swagger-api.schema.apps.metadata`.