### PR TITLE
CORE-11 Import /apps/{app-id}/communities docs

### DIFF
--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -7,6 +7,7 @@
                                           SortFieldDocs
                                           SortFieldOptionalKey]]
         [common-swagger-api.schema.apps.rating :only [Rating]]
+        [common-swagger-api.schema.metadata :only [AvuListRequest]]
         [common-swagger-api.schema.ontologies :only [OntologyHierarchyList]]
         [common-swagger-api.schema.tools :only [Tool ToolDetails ToolListingImage ToolListingItem]]
         [schema.core :only [defschema
@@ -627,8 +628,13 @@
              OptionalToolsKey (describe [AppToolRequest] ToolListDocs))
       (describe "The App to preview.")))
 
-(defschema AppCategoryMetadata
-  {(optional-key :avus) (describe [Any] "A listing of App Category metadata")})
+(defschema AppCategoryMetadataAddRequest
+  (-> AvuListRequest
+      (describe "Community metadata to add to the App.")))
+
+(defschema AppCategoryMetadataDeleteRequest
+  (-> AvuListRequest
+      (describe "Community metadata to remove from the App.")))
 
 (defschema PublishAppRequest
   (-> AppBase
@@ -637,7 +643,8 @@
       (->optional-param :description)
       (assoc (optional-key :documentation) AppDocParam
              (optional-key :references) AppReferencesParam)
-      (merge AppCategoryMetadata)
+      (merge AppCategoryMetadataAddRequest)
+      (->optional-param :avus)
       (describe "The user's Publish App Request.")))
 
 (defschema AppPublishableResponse

--- a/src/common_swagger_api/schema/apps/communities.clj
+++ b/src/common_swagger_api/schema/apps/communities.clj
@@ -1,0 +1,13 @@
+(ns common-swagger-api.schema.apps.communities)
+
+(def AppCommunityMetadataAddSummary "Add/Update Community Metadata AVUs")
+(def AppCommunityMetadataAddDocs
+  "Adds or updates Community Metadata AVUs on the app.
+   The authenticated user must be a community admin for every Community AVU in the request,
+   in order to add or edit this metadata.")
+
+(def AppCommunityMetadataDeleteSummary "Remove Community Metadata AVUs")
+(def AppCommunityMetadataDeleteDocs
+  "Removes the given Community AVUs associated with an app.
+   The authenticated user must be a community admin for every Community AVU in the request,
+   in order to remove those AVUs.")

--- a/src/common_swagger_api/schema/metadata.clj
+++ b/src/common_swagger_api/schema/metadata.clj
@@ -32,7 +32,7 @@
              (describe [(s/recursive #'AvuRequest)] "AVUs attached to this AVU"))))
 
 (s/defschema AvuListRequest
-  (-> {:avus (describe [AvuRequest] "The AVUs to save for the target data item")}
+  (-> {:avus (describe [AvuRequest] "The AVUs to save for the target item")}
       (describe "The Metadata AVU update request")))
 
 (s/defschema SetAvuRequest


### PR DESCRIPTION
This PR will import `/apps/{app-id}/communities` endpoint docs from `apps.routes.apps.communities`, and replace `common-swagger-api.schema.apps/AppCategoryMetadata` with request schemas that use `common-swagger-api.schema.metadata/AvuListRequest`.