### PR TITLE
CORE-11 Import remaining /tools endpoint schemas and docs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/common-swagger-api "2.10.8-SNAPSHOT"
+(defproject org.cyverse/common-swagger-api "2.11.0-SNAPSHOT"
   :description "Common library for Swagger documented RESTful APIs"
   :url "https://github.com/cyverse-de/common-swagger-api"
   :license {:name "BSD"

--- a/resources/docs/tools/tool-add.md
+++ b/resources/docs/tools/tool-add.md
@@ -1,0 +1,8 @@
+This service adds a new private Tool to the DE for the requesting user.
+
+Note that `type` is set to `executable` by default, `restricted` is always set to `true`,
+and `container.network_mode` is set to `none` unless the requested `type` is `interactive`.
+
+Configured default values will be used for the `time_limit_seconds`, `container.pids_limit`, and `container.memory_limit` fields.
+The request may include a value less than the configured default if it's also greater than 0,
+otherwise the default value will be used.

--- a/resources/docs/tools/tool-update.md
+++ b/resources/docs/tools/tool-update.md
@@ -1,0 +1,9 @@
+This service updates a private Tool definition in the DE.
+As with new private Tools, `restricted` is always set to `true`,
+and a configured limit may override the `time_limit_seconds` field set in the request.
+
+**Note**: If the `container` object is omitted in the request, then existing container settings will not be modified,
+but if the `container` object is present in the request, then all container settings must be included in it.
+Any existing settings not included in the request's `container` object will be removed,
+except `network_mode` is always set to `none` (or `bridge` for `interactive` types)
+and configured limits may override values set (or omitted) for the `pids_limit` and `memory_limit` fields.

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -1,9 +1,11 @@
 (ns common-swagger-api.schema.apps
   (:use [common-swagger-api.schema
          :only [->optional-param
+                CommonResponses
                 describe
-                optional-key->keyword
+                ErrorResponseNotFound
                 NonBlankString
+                optional-key->keyword
                 PagingParams
                 SortFieldDocs
                 SortFieldOptionalKey]]
@@ -711,3 +713,10 @@
 
    (optional-key :archive_logs)
    (describe Bool "True if the job logs should be uploaded to the data store.")})
+
+(def ToolAppListingResponses
+  (merge CommonResponses
+         {200 {:schema      AppListing
+               :description "The listing of Apps using the given Tool."}
+          404 {:schema      ErrorResponseNotFound
+               :description "The `tool-id` does not exist."}}))

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -1,15 +1,20 @@
 (ns common-swagger-api.schema.apps
-  (:use [common-swagger-api.schema :only [->optional-param
-                                          describe
-                                          optional-key->keyword
-                                          NonBlankString
-                                          PagingParams
-                                          SortFieldDocs
-                                          SortFieldOptionalKey]]
+  (:use [common-swagger-api.schema
+         :only [->optional-param
+                describe
+                optional-key->keyword
+                NonBlankString
+                PagingParams
+                SortFieldDocs
+                SortFieldOptionalKey]]
         [common-swagger-api.schema.apps.rating :only [Rating]]
         [common-swagger-api.schema.metadata :only [AvuListRequest]]
         [common-swagger-api.schema.ontologies :only [OntologyHierarchyList]]
-        [common-swagger-api.schema.tools :only [Tool ToolDetails ToolListingImage ToolListingItem]]
+        [common-swagger-api.schema.tools
+         :only [Tool
+                ToolDetails
+                ToolListingImage
+                ToolListingItem]]
         [schema.core :only [defschema
                             enum
                             optional-key
@@ -163,10 +168,6 @@
 (def TreeSelectorGroupParameterListDocs "The TreeSelector Group's arguments")
 (def TreeSelectorGroupGroupListDocs "The TreeSelector Group's groups")
 (def AppListingJobStatsDocs "Some launch statistics associated with the App")
-
-(defschema IncludeHiddenParams
-  {(optional-key :include-hidden)
-   (describe Boolean "True if hidden elements should be included in the results.")})
 
 (defschema AppParameterListItem
   {:id                         (describe UUID "A UUID that is used to identify the List Item")

--- a/src/common_swagger_api/schema/apps/permission.clj
+++ b/src/common_swagger_api/schema/apps/permission.clj
@@ -1,7 +1,8 @@
 (ns common-swagger-api.schema.apps.permission
   (:use [common-swagger-api.schema :only [describe ErrorResponse NonBlankString]]
         [common-swagger-api.schema.apps :only [QualifiedAppId]]
-        [schema.core :only [defschema enum optional-key]]))
+        [schema.core :only [defschema enum optional-key]])
+  (:import (java.util UUID)))
 
 (def AppPermissionListingSummary "List App Permissions")
 (def AppPermissionListingDocs
@@ -26,6 +27,7 @@
    Note: like app sharing, this is a potentially slow operation.")
 
 (def AppPermissionEnum (enum "read" "write" "own" ""))
+(def ToolPermissionEnum AppPermissionEnum)
 
 (defschema PermissionListerQueryParams
   {(optional-key :full-listing)
@@ -99,3 +101,59 @@
 
 (defschema AppUnsharingResponse
   {:unsharing (describe [SubjectAppUnsharingResponseElement] "The list of app unsharing responses")})
+
+(defschema ToolIdList
+  {:tools (describe [UUID] "A List of Tool IDs")})
+
+(defschema ToolPermissionListElement
+  {:id          (describe UUID "The Tool ID")
+   :name        (describe NonBlankString "The Tool name")
+   :permissions (describe [SubjectPermissionListElement] "The list of subject permissions for the Tool")})
+
+(defschema ToolPermissionListing
+  {:tools (describe [ToolPermissionListElement] "The list of Tool permissions")})
+
+(defschema ToolSharingRequestElement
+  {:tool_id    (describe UUID "The Tool ID")
+   :permission (describe ToolPermissionEnum "The requested permission level")})
+
+(defschema ToolSharingResponseElement
+  (assoc ToolSharingRequestElement
+    :tool_name            (describe NonBlankString "The Tool name")
+    :success              (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
+    (optional-key :error) (describe ErrorResponse "Information about any error that may have occurred")))
+
+(defschema SubjectToolSharingRequestElement
+  {:subject (describe Subject "The user or group identification.")
+   :tools   (describe [ToolSharingRequestElement] "The list of Tool sharing requests for the subject")})
+
+(defschema SubjectToolSharingResponseElement
+  (assoc SubjectToolSharingRequestElement
+    :tools (describe [ToolSharingResponseElement] "The list of Tool sharing responses for the subject")))
+
+(defschema ToolSharingRequest
+  {:sharing (describe [SubjectToolSharingRequestElement] "The list of Tool sharing requests")})
+
+(defschema ToolSharingResponse
+  {:sharing (describe [SubjectToolSharingResponseElement] "The list of Tool sharing responses")})
+
+(defschema ToolUnsharingResponseElement
+  {:tool_id              (describe UUID "The Tool ID")
+   :tool_name            (describe NonBlankString "The Tool name")
+   :success              (describe Boolean "A Boolean flag indicating whether the unsharing request succeeded")
+   (optional-key :error) (describe ErrorResponse "Information about any error that may have occurred")})
+
+(defschema SubjectToolUnsharingRequestElement
+  {:subject (describe Subject "The user or group identification.")
+   :tools   (describe [UUID] "The identifiers of the Tools to unshare")})
+
+(defschema SubjectToolUnsharingResponseElement
+  (assoc SubjectToolUnsharingRequestElement
+    :tools (describe [ToolUnsharingResponseElement] "The list of Tool unsharing responses for the subject")))
+
+(defschema ToolUnsharingRequest
+  {:unsharing (describe [SubjectToolUnsharingRequestElement] "The list of unsharing requests for individual subjects")})
+
+(defschema ToolUnsharingResponse
+  {:unsharing
+   (describe [SubjectToolUnsharingResponseElement] "The list of unsharing responses for individual subjects")})

--- a/src/common_swagger_api/schema/common.clj
+++ b/src/common_swagger_api/schema/common.clj
@@ -1,0 +1,7 @@
+(ns common-swagger-api.schema.common
+  (:use [common-swagger-api.schema :only [describe]]
+        [schema.core :only [defschema optional-key]]))
+
+(defschema IncludeHiddenParams
+  {(optional-key :include-hidden)
+   (describe Boolean "True if hidden elements should be included in the results.")})

--- a/src/common_swagger_api/schema/containers.clj
+++ b/src/common_swagger_api/schema/containers.clj
@@ -12,6 +12,11 @@
        (s/optional-key :osg_image_path) (s/maybe s/Str)}
       (describe "A map describing a container image.")))
 
+(s/defschema NewImage
+  (-> Image
+      (dissoc :id)
+      (describe "The values needed to add a new image to a tool.")))
+
 (s/defschema Settings
   (-> {(s/optional-key :cpu_shares)        (describe Integer "The shares of the CPU that the tool container will receive")
        (s/optional-key :pids_limit)        Integer
@@ -29,17 +34,32 @@
        :id                                 s/Uuid}
       (describe "The group of settings for a container.")))
 
+(s/defschema NewSettings
+  (-> Settings
+      (->optional-param :id)
+      (describe "The values needed to add a new container to a tool.")))
+
 (s/defschema Device
   (-> {:host_path      (describe s/Str "A device's path on the container host")
        :container_path (describe s/Str "A device's path inside the tool container")
        :id             s/Uuid}
       (describe "Information about a device associated with a tool's container.")))
 
+(s/defschema NewDevice
+  (-> Device
+      (dissoc :id)
+      (describe "The map needed to add a device to a container.")))
+
 (s/defschema Volume
   (-> {:host_path      (describe s/Str "The path to a bind mounted volume on the host machine")
        :container_path (describe s/Str "The path to a bind mounted volume in the tool container")
        :id             s/Uuid}
       (describe "A map representing a bind mounted container volume.")))
+
+(s/defschema NewVolume
+  (-> Volume
+      (dissoc :id)
+      (describe "A map for adding a new volume to a container.")))
 
 (s/defschema DataContainer
   (-> (merge (dissoc Image :id)
@@ -51,12 +71,22 @@
 (s/defschema VolumesFrom
   (describe DataContainer "A description of a data container volumes-from settings."))
 
+(s/defschema NewVolumesFrom
+  (-> VolumesFrom
+      (dissoc :id)
+      (describe "A map for adding a new container from which to bind mount volumes.")))
+
 (s/defschema Port
   (-> {:id                            s/Uuid
        (s/optional-key :host_port)    (s/maybe Integer)
        :container_port                Integer
        (s/optional-key :bind_to_host) (s/maybe Boolean)}
       (describe "Port information for a tool container.")))
+
+(s/defschema NewPort
+  (-> Port
+      (dissoc :id)
+      (describe "A map for adding a new port configuration to a tool container.")))
 
 (s/defschema ProxySettings
   (-> {:id                             s/Uuid
@@ -68,6 +98,11 @@
        (s/optional-key :ssl_cert_path) (s/maybe String)
        (s/optional-key :ssl_key_path)  (s/maybe String)}
       (describe "Interactive app settings for the reverse proxy that runs on the HTCondor nodes for each job.")))
+
+(s/defschema NewProxySettings
+  (-> ProxySettings
+      (dissoc :id)
+      (describe "A map for adding new interactive app reverse proxy settings.")))
 
 (def DevicesParamOptional       (s/optional-key :container_devices))
 (def VolumesParamOptional       (s/optional-key :container_volumes))
@@ -84,3 +119,13 @@
               ProxySettingsParamOptional ProxySettings
               :image                     Image})
       (describe "All container and container image information associated with a tool.")))
+
+(s/defschema NewToolContainer
+  (-> (merge NewSettings
+             {DevicesParamOptional       [NewDevice]
+              VolumesParamOptional       [NewVolume]
+              VolumesFromParamOptional   [NewVolumesFrom]
+              PortsParamOptional         [NewPort]
+              ProxySettingsParamOptional NewProxySettings
+              :image                     NewImage})
+      (describe "The settings for adding a new full container definition to a tool.")))

--- a/src/common_swagger_api/schema/tools.clj
+++ b/src/common_swagger_api/schema/tools.clj
@@ -1,6 +1,13 @@
 (ns common-swagger-api.schema.tools
   (:use [clojure-commons.error-codes]
-        [common-swagger-api.schema :only [->optional-param describe ErrorResponse]]
+        [common-swagger-api.schema
+         :only [->optional-param
+                CommonResponses
+                describe
+                ErrorResponse
+                ErrorResponseForbidden
+                ErrorResponseNotFound
+                ErrorResponseNotWritable]]
         [common-swagger-api.schema.common :only [IncludeHiddenParams]]
         [common-swagger-api.schema.containers
          :only [DevicesParamOptional
@@ -12,6 +19,39 @@
                 VolumesParamOptional]]
         [schema.core :only [defschema enum optional-key]])
   (:import (java.util UUID)))
+
+(def ToolAddSummary "Add Private Tool")
+
+(def ToolAppListingSummary "Get Apps by Tool")
+(def ToolAppListingDocs
+  "This endpoint returns a listing of Apps using the given Tool.")
+
+(def ToolDeleteSummary "Delete a Private Tool")
+(def ToolDeleteDocs
+  "Deletes a private Tool, as long as it is not in use by any Apps.
+   The requesting user must have ownership permission for the Tool.
+   If the Tool is already in use in private Apps,
+   then an `ERR_NOT_WRITEABLE` will be returned along with a listing of the Apps using this Tool,
+   unless the `force-delete` flag is set to `true`.")
+
+(def ToolDetailsSummary "Get a Tool")
+(def ToolDetailsDocs
+  "This endpoint returns the details for one tool accessible to the user.")
+
+(def ToolIntegrationDataListingSummary "Return the Integration Data Record for a Tool")
+(def ToolIntegrationDataListingDocs
+  "This service returns the integration data associated with an app.")
+
+(def ToolListingSummary "List Tools")
+(def ToolListingDocs
+  "This endpoint allows users to get a listing of all Tools accessible to the user.")
+
+(def ToolPermissionsListingSummary "List Tool Permissions")
+(def ToolPermissionsListingDocs
+  "This endpoint allows the caller to list the permissions for one or more Tools.
+   The authenticated user must have read permission on every Tool in the request body for this endpoint to succeed.")
+
+(def ToolUpdateSummary "Update a Private Tool")
 
 (def ToolIdParam (describe UUID "A UUID that is used to identify the Tool"))
 (def ToolRequestIdParam (describe UUID "The Tool Requests's UUID"))
@@ -26,7 +66,7 @@
 
 (defschema ToolSearchParams
   (merge IncludeHiddenParams
-         {(optional-key :search) (describe String "The pattern to match in an Tool's Name or Description.")
+         {(optional-key :search) (describe String "The pattern to match in a Tool's Name or Description.")
           (optional-key :public) (describe Boolean
                                            "Set to `true` to list only public Tools, `false` to list only private Tools,
                                             or leave unset to list all Tools.")}))
@@ -88,13 +128,15 @@
   (-> ToolImportRequest
       (->optional-param :type)
       (->optional-param :implementation)
-      (merge {:container PrivateToolContainerImportRequest})))
+      (merge {:container PrivateToolContainerImportRequest})
+      (describe "The private Tool to import.")))
 
 (defschema PrivateToolUpdateRequest
   (-> PrivateToolImportRequest
       (->optional-param :name)
       (->optional-param :version)
-      (->optional-param :container)))
+      (->optional-param :container)
+      (describe "The private Tool to update.")))
 
 (defschema ToolRequestSummary
   {:id                     ToolRequestIdParam
@@ -128,3 +170,34 @@
    :description "
 * `ERR_EXISTS`: A Tool with the given `name` already exists.
 * `ERR_BAD_OR_MISSING_FIELD`: The image with the given `name` and `tag` has been deprecated."})
+
+(def PrivateToolImportResponses
+  (merge CommonResponses
+         {200 {:schema      ToolDetails
+               :description "The new Tool details."}
+          400 PrivateToolImportResponse400}))
+
+(def ToolDeleteResponses
+  (merge CommonResponses
+         {200 {:description "The Tool was successfully deleted."}
+          400 {:schema      ErrorResponseNotWritable
+               :description "The Tool could not be deleted."}
+          403 {:schema      ErrorResponseForbidden
+               :description "The requesting user does not have permission to delete this Tool."}
+          404 {:schema      ErrorResponseNotFound
+               :description "A Tool with the given `tool-id` does not exist."}}))
+
+(def ToolDetailsResponses
+  (merge CommonResponses
+         {200 {:schema      ToolDetails
+               :description "The Tool details."}
+          403 {:schema      ErrorResponseForbidden
+               :description "The requesting user does not have `read` permission for the Tool."}
+          404 {:schema      ErrorResponseNotFound
+               :description "The `tool-id` does not exist."}}))
+
+(def ToolUpdateResponses
+  (merge CommonResponses
+         {200 {:schema      ToolDetails
+               :description "The updated Tool details."}
+          400 PrivateToolImportResponse400}))


### PR DESCRIPTION
This PR will import the remaining `/tools` endpoint schemas and docs from `apps.routes.tools`, `apps.routes.schemas.tool`, `apps.routes.schemas.containers`, and `apps.routes.schemas.permission` to `common-swagger-api.schema.tools`, `common-swagger-api.schema.containers`, and `common-swagger-api.schema.apps.permission`.

Also moves `common-swagger-api.schema.apps/IncludeHiddenParams` to `common-swagger-api.schema.common/IncludeHiddenParams`.