### PR TITLE
CORE-11 Import /analyses endpoint schemas and docs

### DIFF
--- a/resources/docs/analyses/listing/filter-param.md
+++ b/resources/docs/analyses/listing/filter-param.md
@@ -1,0 +1,22 @@
+Allows results to be filtered based on the value of some result field.
+The format of this parameter is
+`[{"field":"some_field", "value":"search-term"}, ...]`,
+where `field` is the name of the field on which the filter is based and `value` is the search value.
+If `field` is `name` or `app_name`, then `value` can be contained anywhere, case-insensitive, in the corresponding field.
+For example, to obtain the list of all jobs that were executed using an application with `CACE` anywhere in its name,
+the parameter value can be `[{"field":"app_name","value":"cace"}]`.
+To find a job with a specific `id`, the parameter value can be
+`[{"field":"id","value":"C09F5907-B2A2-4429-A11E-5B96F421C3C1"}]`.
+To find jobs associated with a specific `parent_id`, the parameter value can be
+`[{"field":"parent_id","value":"b4c2f624-7cbd-496e-adad-5be8d0d3b941"}]`.
+It's also possible to search for jobs without a parent using this parameter value:
+`[{"field":"parent_id","value":null}]`.
+The `ownership` field can be used to specify whether analyses that belong to the authenticated user
+or analyses that are shared with the authenticated user should be listed.
+If the value is `all` then all analyses that are visible to the user will be listed.
+If the value is `mine` then only analyses that were submitted by the user will be listed.
+If the value is `theirs` then only analyses that have been shared with the user will be listed.
+By default, all analyses are listed.
+The `ownership` field is the only field for which only one filter value is supported.
+If multiple `ownership` field values are specified then the first value specified is used.
+Here's an example: `[{"field":"ownership","value":"mine"}]`.

--- a/src/common_swagger_api/schema/analyses.clj
+++ b/src/common_swagger_api/schema/analyses.clj
@@ -9,6 +9,20 @@
                 Keyword]])
   (:import (java.util UUID)))
 
+(def AnalysisParametersSummary "Display the parameters used in an analysis.")
+(def AnalysisParametersDocs
+  "This service returns a list of parameter values used in a previously executed analysis.")
+
+(def AnalysisRelaunchSummary "Obtain information to relaunch analysis.")
+(def AnalysisRelaunchDocs
+  "This service allows the Discovery Environment user interface to obtain an app description
+   that can be used to relaunch a previously submitted job,
+   possibly with modified parameter values.")
+
+(def AnalysisStopSummary "Stop a running analysis.")
+(def AnalysisStopDocs
+  "This service allows DE users to stop running analyses.")
+
 (def AnalysisIdPathParam (describe UUID "The Analysis UUID"))
 
 (defschema ParameterValue

--- a/src/common_swagger_api/schema/analyses.clj
+++ b/src/common_swagger_api/schema/analyses.clj
@@ -1,0 +1,125 @@
+(ns common-swagger-api.schema.analyses
+  (:use [common-swagger-api.schema :only [describe]]
+        [common-swagger-api.schema.apps :only [SystemId]]
+        [schema.core
+         :only [defschema
+                enum
+                optional-key
+                Any
+                Keyword]])
+  (:import (java.util UUID)))
+
+(def AnalysisIdPathParam (describe UUID "The Analysis UUID"))
+
+(defschema ParameterValue
+  {:value
+   (describe Any "The value of the parameter.")})
+
+(defschema AnalysisParameter
+  {:full_param_id
+   (describe String "The fully qualified parameter ID.")
+
+   :param_id
+   (describe String "The unqualified parameter ID.")
+
+   (optional-key :param_name)
+   (describe String "The name of the parameter.")
+
+   (optional-key :param_value)
+   (describe ParameterValue "The value of the parameter.")
+
+   :param_type
+   (describe String "The type of the parameter.")
+
+   (optional-key :info_type)
+   (describe String "The type of information associated with an input or output parameter.")
+
+   (optional-key :data_format)
+   (describe String "The data format associated with an input or output parameter.")
+
+   (optional-key :is_default_value)
+   (describe Boolean "Indicates whether the default parameter value was used.")
+
+   (optional-key :is_visible)
+   (describe Boolean "Indicates whether the parameter is visible in the app UI.")})
+
+(defschema AnalysisParameters
+  {:app_id     (describe String "The ID of the app used to perform the analysis.")
+   :system_id  SystemId
+   :parameters (describe [AnalysisParameter] "The list of parameters.")})
+
+(defschema AnalysisShredderRequest
+  {:analyses (describe [UUID] "The identifiers of the analyses to be deleted.")})
+
+(defschema StopAnalysisRequest
+  {(optional-key :job_status)
+   (describe (enum "Canceled" "Completed" "Failed") "The job status to set. Defaults to `Canceled`")})
+
+(defschema StopAnalysisResponse
+  {:id (describe UUID "the ID of the stopped analysis.")})
+
+(defschema FileMetadata
+  {:attr  (describe String "The attribute name.")
+   :value (describe String "The attribute value.")
+   :unit  (describe String "The attribute unit.")})
+
+(defschema AnalysisSubmissionConfig
+  {(describe Keyword "The step-ID_param-ID") (describe Any "The param-value")})
+
+(defschema AnalysisSubmission
+  {:system_id
+   SystemId
+
+   :app_id
+   (describe String "The ID of the app used to perform the analysis.")
+
+   (optional-key :job_id)
+   (describe UUID "The UUID of the job being submitted.")
+
+   (optional-key :callback)
+   (describe String "The callback URL to use for job status updates.")
+
+   :config
+   (describe AnalysisSubmissionConfig "A map from (str step-id \"_\" param-id) to param-value.")
+
+   (optional-key :create_output_subdir)
+   (describe Boolean "Indicates whether a subdirectory should be created beneath the specified output directory.")
+
+   :debug
+   (describe Boolean "A flag indicating whether or not job debugging should be enabled.")
+
+   (optional-key :description)
+   (describe String "An optional description of the analysis.")
+
+   :name
+   (describe String "The name assigned to the analysis by the user.")
+
+   :notify
+   (describe Boolean "Indicates whether the user wants to receive job status update notifications.")
+
+   :output_dir
+   (describe String "The path to the analysis output directory in the data store.")
+
+   (optional-key :starting_step)
+   (describe Long "The ordinal number of the step to start the job with.")
+
+   (optional-key :uuid)
+   (describe UUID "The UUID of the analysis. A random UUID will be assigned if one isn't provided.")
+
+   (optional-key :skip-parent-meta)
+   (describe Boolean "True if metadata should not associate metadata with the parent directory.")
+
+   (optional-key :file-metadata)
+   (describe [FileMetadata] "Custom file attributes to associate with result files.")
+
+   (optional-key :archive_logs)
+   (describe Boolean "True if the job logs should be uploaded to the data store.")})
+
+(defschema AnalysisResponse
+  {:id         (describe UUID "The ID of the submitted analysis.")
+   :name       (describe String "The name of the submitted analysis.")
+   :status     (describe String "The current status of the analysis.")
+   :start-date (describe String "The analysis start date as milliseconds since the epoch.")
+
+   (optional-key :missing-paths)
+               (describe [String] "Any paths parsed from an HT Analysis Path List that no longer exist.")})

--- a/src/common_swagger_api/schema/analyses/listing.clj
+++ b/src/common_swagger_api/schema/analyses/listing.clj
@@ -1,0 +1,150 @@
+(ns common-swagger-api.schema.analyses.listing
+  (:use [common-swagger-api.schema :only [describe NonBlankString]]
+        [common-swagger-api.schema.apps :only [SystemId]]
+        [common-swagger-api.schema.common :only [IncludeHiddenParams]]
+        [schema.core
+         :only [defschema
+                maybe
+                optional-key]])
+  (:require [clojure.java.io :as io])
+  (:import (java.util UUID)))
+
+;; JSON query params are not currently supported by compojure-api,
+;; so we have to define "filter" in this schema as a String for now.
+(def OptionalKeyFilter (optional-key :filter))
+
+(defschema AnalysisListingParams
+  (merge IncludeHiddenParams
+         {OptionalKeyFilter
+          (describe String (slurp (io/resource "docs/analyses/listing/filter-param.md")))}))
+
+(def ResultsTotalParam
+  (describe Long "The total number of results that would be returned without limits and offsets applied."))
+
+(def Timestamp (describe String "A timestamp in milliseconds since the epoch."))
+(def ExternalId (describe NonBlankString "The analysis identifier from the job execution system."))
+
+(defschema BatchStatus
+  {:total     (describe Integer "The total number of jobs in the batch.")
+   :completed (describe Integer "The number of completed jobs in the batch.")
+   :running   (describe Integer "The number of running jobs in the batch.")
+   :submitted (describe Integer "The number of submitted jobs in the batch.")})
+
+(defschema BaseAnalysis
+  {(optional-key :app_description)
+   (describe String "A description of the app used to perform the analysis.")
+
+   :app_id
+   (describe String "The ID of the app used to perform the analysis.")
+
+   :system_id
+   SystemId
+
+   (optional-key :app_name)
+   (describe String "The name of the app used to perform the analysis.")
+
+   (optional-key :batch)
+   (describe Boolean "Indicates whether the analysis is a batch analysis.")
+
+   (optional-key :description)
+   (describe String "The analysis description.")
+
+   (optional-key :enddate)
+   (describe Timestamp "The time the analysis ended.")
+
+   :id
+   (describe UUID "The analysis ID.")
+
+   (optional-key :name)
+   (describe String "The analysis name.")
+
+   :notify
+   (describe Boolean "Indicates whether the user wants status updates via email.")
+
+   (optional-key :resultfolderid)
+   (describe String "The path to the folder containing the anlaysis results.")
+
+   (optional-key :startdate)
+   (describe Timestamp "The time the analysis started.")
+
+   :status
+   (describe String "The status of the analysis.")
+
+   :username
+   (describe String "The name of the user who submitted the analysis.")
+
+   (optional-key :wiki_url)
+   (describe String "The URL to app documentation in Confluence.")
+
+   (optional-key :parent_id)
+   (describe UUID "The identifier of the parent analysis.")
+
+   (optional-key :batch_status)
+   (describe BatchStatus "A summary of the status of the batch.")
+
+   (optional-key :interactive_urls)
+   (describe [String] "The list of externally accessible interactive analysis URLs.")})
+
+(defschema Analysis
+  (assoc BaseAnalysis
+    :app_disabled
+    (describe Boolean "Indicates whether the app is currently disabled.")
+
+    :can_share
+    (describe Boolean "Indicates whether or not the analysis can be shared.")))
+
+(defschema AnalysisList
+  {:analyses  (describe [Analysis] "The list of analyses.")
+   :timestamp (describe Timestamp "The time the analysis list was retrieved.")
+   :total     ResultsTotalParam})
+
+(defschema AnalysisUpdate
+  (select-keys Analysis (map optional-key [:description :name])))
+
+(defschema AnalysisUpdateResponse
+  (select-keys Analysis (cons :id (map optional-key [:description :name]))))
+
+(def AppStepNumber
+  (describe Integer (str "The sequential step number from the app, which might be different "
+                         "from the analysis step number if app steps have been combined.")))
+
+(defschema AnalysisStep
+  {:step_number
+   (describe Integer "The sequential step number in the analysis.")
+
+   (optional-key :external_id)
+   (describe String "The step ID from the execution system.")
+
+   (optional-key :startdate)
+   (describe Timestamp "The time the step started.")
+
+   (optional-key :enddate)
+   (describe Timestamp "The time the step ended.")
+
+   (optional-key :status)
+   (describe String "The status of the step.")
+
+   (optional-key :app_step_number)
+   AppStepNumber
+
+   (optional-key :step_type)
+   (describe String "The analysis type associated with the step.")})
+
+(defschema AnalysisStepList
+  {:analysis_id (describe UUID "The analysis ID.")
+   :steps       (describe [AnalysisStep] "The list of analysis steps.")
+   :timestamp   (describe Timestamp "The time the list of analysis steps was retrieved.")
+   :total       ResultsTotalParam})
+
+(defschema AnalysisStatusUpdate
+  {:status    (describe NonBlankString "The job status associated with the update.")
+   :message   (describe String "A brief description of the job status update.")
+   :timestamp (describe String "The date and time when the job status update was created.")})
+
+(defschema AnalysisStepHistory
+  (assoc AnalysisStep
+    :updates (describe [AnalysisStatusUpdate] "The list of updates received for the analysis step.")))
+
+(defschema AnalysisHistory
+  (assoc AnalysisStepList
+    :steps (describe [AnalysisStepHistory] "The history of each step in the analysis.")))

--- a/src/common_swagger_api/schema/analyses/listing.clj
+++ b/src/common_swagger_api/schema/analyses/listing.clj
@@ -9,6 +9,37 @@
   (:require [clojure.java.io :as io])
   (:import (java.util UUID)))
 
+(def AnalysesDeleteSummary "Delete Multiple Analyses")
+(def AnalysesDeleteDocs
+  "This service allows the caller to mark one or more analyses as deleted in the apps database.")
+
+(def AnalysesListingSummary "List Analyses")
+(def AnalysesListingDocs
+  "This service allows users to list analyses that they've previously submitted for execution.")
+
+(def AnalysisDeleteSummary "Delete an Analysis")
+(def AnalysisDeleteDocs
+  "This service marks an analysis as deleted in the DE database.")
+
+(def AnalysisHistorySummary "Get the Status Update History of an Analysis")
+(def AnalysisHistoryDocs
+  "This endpoint returns a status update history for each step in an analysis.")
+
+(def AnalysisStepsSummary "Display the steps of an analysis.")
+(def AnalysisStepsDocs
+  "This service returns a list of steps in an analysis.")
+
+(def AnalysisSubmitSummary "Submit an Analysis")
+(def AnalysisSubmitDocs
+  "This service allows users to submit analyses for execution.
+   The `config` element in the analysis submission is a map
+   from parameter IDs as they appear in the response from the `/apps/:app-id` endpoint
+   to the desired values for those parameters.")
+
+(def AnalysisUpdateSummary "Update an Analysis")
+(def AnalysisUpdateDocs
+  "This service allows an analysis name or description to be updated.")
+
 ;; JSON query params are not currently supported by compojure-api,
 ;; so we have to define "filter" in this schema as a String for now.
 (def OptionalKeyFilter (optional-key :filter))

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -17,13 +17,12 @@
                 ToolDetails
                 ToolListingImage
                 ToolListingItem]]
-        [schema.core :only [defschema
-                            enum
-                            optional-key
-                            recursive
-                            Any
-                            Bool
-                            Keyword]])
+        [schema.core
+         :only [defschema
+                enum
+                optional-key
+                recursive
+                Any]])
   (:require [clojure.set :as sets])
   (:import [java.util UUID Date]))
 
@@ -653,66 +652,6 @@
 (defschema AppPublishableResponse
   {:publishable           (describe Boolean "True if the app is publishable.")
    (optional-key :reason) (describe String "The reason the app can't be published if it's not publishable.")})
-
-(defschema FileMetadata
-  {:attr  (describe String "The attribute name.")
-   :value (describe String "The attribute value.")
-   :unit  (describe String "The attribute unit.")})
-
-(defschema AnalysisSubmissionConfig
-  {(describe Keyword "The step-ID_param-ID") (describe Any "The param-value")})
-
-(defschema AnalysisSubmission
-  {:system_id
-   SystemId
-
-   :app_id
-   (describe String "The ID of the app used to perform the analysis.")
-
-   (optional-key :job_id)
-   (describe UUID "The UUID of the job being submitted.")
-
-   (optional-key :callback)
-   (describe String "The callback URL to use for job status updates.")
-
-   :config
-   (describe AnalysisSubmissionConfig "A map from (str step-id \"_\" param-id) to param-value.")
-
-   (optional-key :create_output_subdir)
-   (describe Bool (str "Indicates whether a subdirectory should be created beneath "
-                       "the specified output directory."))
-
-   :debug
-   (describe Bool "A flag indicating whether or not job debugging should be enabled.")
-
-   (optional-key :description)
-   (describe String "An optional description of the analysis.")
-
-   :name
-   (describe String "The name assigned to the analysis by the user.")
-
-   :notify
-   (describe Bool (str "Indicates whether the user wants to receive job status update "
-                       "notifications."))
-
-   :output_dir
-   (describe String "The path to the analysis output directory in the data store.")
-
-   (optional-key :starting_step)
-   (describe Long "The ordinal number of the step to start the job with.")
-
-   (optional-key :uuid)
-   (describe UUID (str "The UUID of the analysis. A random UUID will be assigned if one isn't "
-                       "provided."))
-
-   (optional-key :skip-parent-meta)
-   (describe Bool "True if metadata should not associate metadata with the parent directory.")
-
-   (optional-key :file-metadata)
-   (describe [FileMetadata] "Custom file attributes to associate with result files.")
-
-   (optional-key :archive_logs)
-   (describe Bool "True if the job logs should be uploaded to the data store.")})
 
 (def ToolAppListingResponses
   (merge CommonResponses

--- a/src/common_swagger_api/schema/apps/permission.clj
+++ b/src/common_swagger_api/schema/apps/permission.clj
@@ -10,6 +10,28 @@
         [schema.core :only [defschema enum optional-key]])
   (:import (java.util UUID)))
 
+(def AnalysisPermissionListingSummary "List Analysis Permissions")
+(def AnalysisPermissionListingDocs
+  "This endpoint allows the caller to list the permissions for one or more analyses.
+   The authenticated user must have read permission on every analysis in the request body for this endpoint to succeed.")
+
+(def AnalysisSharingSummary "Add Analysis Permissions")
+(def AnalysisSharingDocs
+  "This endpoint allows the caller to share multiple analyses with multiple users.
+   The authenticated user must have ownership permission to every analysis in the request body for this endpoint to fully succeed.
+   Note: this is a potentially slow operation and the response is returned synchronously.
+   The DE UI handles this by allowing the user to continue working while the request is being processed.
+   When calling this endpoint, please be sure that the response timeout is long enough.
+   Using a response timeout that is too short will result in an exception on the client side.
+   On the server side, the result of the sharing operation when a connection is lost is undefined.
+   It may be worthwhile to repeat failed or timed out calls to this endpoint.")
+
+(def AnalysisUnsharingSummary "Revoke Analysis Permissions")
+(def AnalysisUnsharingDocs
+  "This endpoint allows the caller to revoke permission to access one or more analyses from one or more users.
+   The authenticate user must have ownership permission to every analysis in the request body for this endoint to fully succeed.
+   Note: like analysis sharing, this is a potentially slow operation.")
+
 (def AppPermissionListingSummary "List App Permissions")
 (def AppPermissionListingDocs
   "This endpoint allows the caller to list the permissions for one or more apps.
@@ -127,7 +149,8 @@
   {:unsharing (describe [SubjectAppUnsharingResponseElement] "The list of app unsharing responses")})
 
 (defschema AnalysisIdList
-  {:analyses (describe [UUID] "A List of analysis IDs")})
+  (-> {:analyses (describe [UUID] "A List of analysis IDs")}
+      (describe "The analysis permission listing request.")))
 
 (defschema AnalysisPermissionListElement
   {:id          (describe UUID "The analysis ID")
@@ -159,7 +182,9 @@
     :analyses (describe [AnalysisSharingResponseElement] "The list of analysis sharing responses for the subject")))
 
 (defschema AnalysisSharingRequest
-  {:sharing (describe [SubjectAnalysisSharingRequestElement] "The list of sharing requests for individual subjects")})
+  (-> {:sharing (describe [SubjectAnalysisSharingRequestElement]
+                          "The list of sharing requests for individual subjects")}
+      (describe "The analysis sharing request.")))
 
 (defschema AnalysisSharingResponse
   {:sharing (describe [SubjectAnalysisSharingResponseElement] "The list of sharing responses for individual subjects")})
@@ -181,8 +206,9 @@
     :analyses (describe [AnalysisUnsharingResponseElement] "The list of analysis unsharing responses for the subject")))
 
 (defschema AnalysisUnsharingRequest
-  {:unsharing
-   (describe [SubjectAnalysisUnsharingRequestElement] "The list of unsharing requests for individual subjects")})
+  (-> {:unsharing (describe [SubjectAnalysisUnsharingRequestElement]
+                            "The list of unsharing requests for individual subjects")}
+      (describe "The analysis unsharing request.")))
 
 (defschema AnalysisUnsharingResponse
   {:unsharing

--- a/src/common_swagger_api/schema/apps/permission.clj
+++ b/src/common_swagger_api/schema/apps/permission.clj
@@ -50,6 +50,7 @@
    Note: like Tool sharing, this is a potentially slow operation.")
 
 (def AppPermissionEnum (enum "read" "write" "own" ""))
+(def AnalysisPermissionEnum (enum "read" "own" ""))
 (def ToolPermissionEnum AppPermissionEnum)
 
 (defschema PermissionListerQueryParams
@@ -124,6 +125,68 @@
 
 (defschema AppUnsharingResponse
   {:unsharing (describe [SubjectAppUnsharingResponseElement] "The list of app unsharing responses")})
+
+(defschema AnalysisIdList
+  {:analyses (describe [UUID] "A List of analysis IDs")})
+
+(defschema AnalysisPermissionListElement
+  {:id          (describe UUID "The analysis ID")
+   :name        (describe NonBlankString "The analysis name")
+   :permissions (describe [SubjectPermissionListElement] "The list of subject permissions for the analysis")})
+
+(defschema AnalysisPermissionListing
+  {:analyses (describe [AnalysisPermissionListElement] "The list of analysis permissions")})
+
+(defschema AnalysisSharingRequestElement
+  {:analysis_id (describe UUID "The analysis ID")
+   :permission  (describe AnalysisPermissionEnum "The requested permission level")})
+
+(defschema AnalysisSharingResponseElement
+  (assoc AnalysisSharingRequestElement
+    :analysis_name                (describe NonBlankString "The analysis name")
+    :success                      (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
+    (optional-key :input_errors)  (describe [NonBlankString] "A list of any analysis input sharing errors")
+    (optional-key :outputs_error) (describe NonBlankString "A brief reason for any result folder sharing errors")
+    (optional-key :app_error)     (describe NonBlankString "A brief reason for any app sharing errors")
+    (optional-key :error)         (describe ErrorResponse "Information about any error that may have occurred")))
+
+(defschema SubjectAnalysisSharingRequestElement
+  {:subject  (describe Subject "The user or group identification.")
+   :analyses (describe [AnalysisSharingRequestElement] "The list of sharing requests for individual analyses")})
+
+(defschema SubjectAnalysisSharingResponseElement
+  (assoc SubjectAnalysisSharingRequestElement
+    :analyses (describe [AnalysisSharingResponseElement] "The list of analysis sharing responses for the subject")))
+
+(defschema AnalysisSharingRequest
+  {:sharing (describe [SubjectAnalysisSharingRequestElement] "The list of sharing requests for individual subjects")})
+
+(defschema AnalysisSharingResponse
+  {:sharing (describe [SubjectAnalysisSharingResponseElement] "The list of sharing responses for individual subjects")})
+
+(defschema AnalysisUnsharingResponseElement
+  {:analysis_id                  (describe UUID "The analysis ID")
+   :analysis_name                (describe NonBlankString "The analysis name")
+   :success                      (describe Boolean "A Boolean flag indicating whether the unsharing request succeeded")
+   (optional-key :input_errors)  (describe [NonBlankString] "A list of any analysis input unsharing errors")
+   (optional-key :outputs_error) (describe NonBlankString "A brief reason for the result folder unsharing error")
+   (optional-key :error)         (describe ErrorResponse "Information about any error that may have occurred")})
+
+(defschema SubjectAnalysisUnsharingRequestElement
+  {:subject  (describe Subject "The user or group identification.")
+   :analyses (describe [UUID] "The identifiers of the analyses to unshare")})
+
+(defschema SubjectAnalysisUnsharingResponseElement
+  (assoc SubjectAnalysisUnsharingRequestElement
+    :analyses (describe [AnalysisUnsharingResponseElement] "The list of analysis unsharing responses for the subject")))
+
+(defschema AnalysisUnsharingRequest
+  {:unsharing
+   (describe [SubjectAnalysisUnsharingRequestElement] "The list of unsharing requests for individual subjects")})
+
+(defschema AnalysisUnsharingResponse
+  {:unsharing
+   (describe [SubjectAnalysisUnsharingResponseElement] "The list of unsharing responses for individual subjects")})
 
 (defschema ToolIdList
   (describe

--- a/src/common_swagger_api/schema/quicklaunches.clj
+++ b/src/common_swagger_api/schema/quicklaunches.clj
@@ -1,8 +1,8 @@
 (ns common-swagger-api.schema.quicklaunches
-  (:use [common-swagger-api.schema :only [describe NonBlankString]])
+  (:use [common-swagger-api.schema :only [describe NonBlankString]]
+        [common-swagger-api.schema.analyses :only [AnalysisSubmission]])
   (:require [schema.core :as s]
-            [schema-tools.core :as st]
-            [common-swagger-api.schema.apps :refer [AnalysisSubmission]])
+            [schema-tools.core :as st])
   (:import [java.util UUID]))
 
 (s/defschema Submission


### PR DESCRIPTION
This PR will move `common-swagger-api.schema.apps/AnalysisSubmission`, `AnalysisSubmissionConfig`, and `FileMetadata` to `common-swagger-api.schema.analyses`, and import the remaining non-admin schemas from `apps.routes.schemas.analysis` to
`common-swagger-api.schema.analyses`.

It will also import non-admin schemas from `apps.routes.schemas.analysis.listing` to `common-swagger-api.schema.analyses.listing`, and the remaining schemas from `apps.routes.schemas.permission` to `common-swagger-api.schema.apps.permission`.

Endpoints docs from `apps.routes.analyses` will also be imported into these namespaces.