### PR TITLE
CORE-11 Replace Integer with schema.core/Int in all schemas.

### DIFF
--- a/src/common_swagger_api/schema/analyses/listing.clj
+++ b/src/common_swagger_api/schema/analyses/listing.clj
@@ -4,6 +4,7 @@
         [common-swagger-api.schema.common :only [IncludeHiddenParams]]
         [schema.core
          :only [defschema
+                Int
                 maybe
                 optional-key]])
   (:require [clojure.java.io :as io])
@@ -57,10 +58,10 @@
 (def ExternalId (describe NonBlankString "The analysis identifier from the job execution system."))
 
 (defschema BatchStatus
-  {:total     (describe Integer "The total number of jobs in the batch.")
-   :completed (describe Integer "The number of completed jobs in the batch.")
-   :running   (describe Integer "The number of running jobs in the batch.")
-   :submitted (describe Integer "The number of submitted jobs in the batch.")})
+  {:total     (describe Int "The total number of jobs in the batch.")
+   :completed (describe Int "The number of completed jobs in the batch.")
+   :running   (describe Int "The number of running jobs in the batch.")
+   :submitted (describe Int "The number of submitted jobs in the batch.")})
 
 (defschema BaseAnalysis
   {(optional-key :app_description)
@@ -137,12 +138,12 @@
   (select-keys Analysis (cons :id (map optional-key [:description :name]))))
 
 (def AppStepNumber
-  (describe Integer (str "The sequential step number from the app, which might be different "
-                         "from the analysis step number if app steps have been combined.")))
+  (describe Int (str "The sequential step number from the app, which might be different "
+                     "from the analysis step number if app steps have been combined.")))
 
 (defschema AnalysisStep
   {:step_number
-   (describe Integer "The sequential step number in the analysis.")
+   (describe Int "The sequential step number in the analysis.")
 
    (optional-key :external_id)
    (describe String "The step ID from the execution system.")

--- a/src/common_swagger_api/schema/containers.clj
+++ b/src/common_swagger_api/schema/containers.clj
@@ -18,8 +18,8 @@
       (describe "The values needed to add a new image to a tool.")))
 
 (s/defschema Settings
-  (-> {(s/optional-key :cpu_shares)        (describe Integer "The shares of the CPU that the tool container will receive")
-       (s/optional-key :pids_limit)        Integer
+  (-> {(s/optional-key :cpu_shares)        (describe s/Int "The shares of the CPU that the tool container will receive")
+       (s/optional-key :pids_limit)        s/Int
        (s/optional-key :memory_limit)      (describe Long "The amount of memory (in bytes) that the tool container is restricted to")
        (s/optional-key :min_memory_limit)  (describe Long "The minimum about of memory (in bytes) that is required to run the tool container")
        (s/optional-key :min_cpu_cores)     (describe Double "The minimum number of CPU cores needed to run the tool container")
@@ -30,7 +30,7 @@
        (s/optional-key :name)              (describe s/Str "The name given to the tool container")
        (s/optional-key :entrypoint)        (describe s/Str "The entrypoint for a tool container")
        (s/optional-key :skip_tmp_mount)    Boolean
-       (s/optional-key :uid)               Integer
+       (s/optional-key :uid)               s/Int
        :id                                 s/Uuid}
       (describe "The group of settings for a container.")))
 
@@ -78,8 +78,8 @@
 
 (s/defschema Port
   (-> {:id                            s/Uuid
-       (s/optional-key :host_port)    (s/maybe Integer)
-       :container_port                Integer
+       (s/optional-key :host_port)    (s/maybe s/Int)
+       :container_port                s/Int
        (s/optional-key :bind_to_host) (s/maybe Boolean)}
       (describe "Port information for a tool container.")))
 

--- a/src/common_swagger_api/schema/tools.clj
+++ b/src/common_swagger_api/schema/tools.clj
@@ -17,7 +17,11 @@
                 ToolContainer
                 VolumesFromParamOptional
                 VolumesParamOptional]]
-        [schema.core :only [defschema enum optional-key]])
+        [schema.core
+         :only [defschema
+                enum
+                Int
+                optional-key]])
   (:import (java.util UUID)))
 
 (def ToolAddSummary "Add Private Tool")
@@ -97,7 +101,7 @@
    :version                           VersionParam
    :type                              (describe String "The Tool Type name")
    (optional-key :restricted)         (describe Boolean "Determines whether a time limit is applied and whether network access is granted")
-   (optional-key :time_limit_seconds) (describe Integer "The number of seconds that a tool is allowed to execute. A value of 0 means the time limit is disabled")
+   (optional-key :time_limit_seconds) (describe Int "The number of seconds that a tool is allowed to execute. A value of 0 means the time limit is disabled")
    (optional-key :interactive)        Interactive})
 
 (defschema ToolDetails


### PR DESCRIPTION
`schema.core/Int` can validate a wider range of integer values, including `long` and `bigint` values.