### PR TITLE
CORE-11 Import coerce-tool-import-requests middleware

### DIFF
--- a/src/common_swagger_api/coerce.clj
+++ b/src/common_swagger_api/coerce.clj
@@ -1,0 +1,9 @@
+(ns common-swagger-api.coerce
+  (:require [ring.swagger.coerce :as rc]))
+
+(defn string->long
+  "When the given map contains the given key, converts its string value to a long."
+  [m k]
+  (if (contains? m k)
+    (update m k rc/string->long)
+    m))

--- a/src/common_swagger_api/schema/containers.clj
+++ b/src/common_swagger_api/schema/containers.clj
@@ -1,6 +1,15 @@
 (ns common-swagger-api.schema.containers
   (:use [common-swagger-api.schema :only [->optional-param describe]])
-  (:require [schema.core :as s]))
+  (:require [common-swagger-api.coerce :as coerce]
+            [schema.core :as s]))
+
+(defn coerce-settings-long-values
+  "Converts any values in the given settings map that should be a Long, according to the Settings schema."
+  [settings]
+  (-> settings
+      (coerce/string->long :memory_limit)
+      (coerce/string->long :min_memory_limit)
+      (coerce/string->long :min_disk_space)))
 
 (s/defschema Image
   (-> {:name                            s/Str

--- a/src/common_swagger_api/schema/tools.clj
+++ b/src/common_swagger_api/schema/tools.clj
@@ -11,7 +11,8 @@
                 PagingParams]]
         [common-swagger-api.schema.common :only [IncludeHiddenParams]]
         [common-swagger-api.schema.containers
-         :only [DevicesParamOptional
+         :only [coerce-settings-long-values
+                DevicesParamOptional
                 Image
                 NewToolContainer
                 Settings
@@ -24,6 +25,24 @@
                 Int
                 optional-key]])
   (:import (java.util UUID)))
+
+(defn- coerce-container-settings-long-values
+  [tool]
+  (if (contains? tool :container)
+    (update tool :container coerce-settings-long-values)
+    tool))
+
+(defn coerce-tool-import-requests
+  "Middleware that converts any container values in the given tool import/update request that should be a Long."
+  [handler]
+  (fn [request]
+    (handler (update request :body-params coerce-container-settings-long-values))))
+
+(defn coerce-tool-list-import-request
+  "Middleware that converts any container values in the given tool list import request that should be a Long."
+  [handler]
+  (fn [request]
+    (handler (update-in request [:body-params :tools] (partial map coerce-container-settings-long-values)))))
 
 (def ToolAddSummary "Add Private Tool")
 


### PR DESCRIPTION
This PR will import `apps.routes.schemas.tool/coerce-tool-import-requests` and `coerce-tool-list-import-request` into `common-swagger-api.schema.tools`, along with related functions into `common-swagger-api.schema.containers` and `common-swagger-api.coerce`.

Missed in #23.