### PR TITLE
CORE-21 Migrate /apps/webhooks schemas

### DIFF
--- a/src/common_swagger_api/schema/webhooks.clj
+++ b/src/common_swagger_api/schema/webhooks.clj
@@ -1,0 +1,36 @@
+(ns common-swagger-api.schema.webhooks
+  (:use [common-swagger-api.schema :only [describe NonBlankString]]
+        [schema.core :only [defschema optional-key]])
+  (:import [java.util UUID]))
+
+(def GetWebhooksSummary "List Webhooks")
+(def GetWebhooksDesc "Returns all of the webhooks defined for the user.")
+(def PutWebhooksSummary "Add a Webhook")
+(def PutWebhooksDesc "Adds a new webhook to the system.")
+(def GetWebhooksTopicSummary "List notification topics")
+(def GetWebhooksTopicDesc "Returns all of the notification topics defined")
+(def GetWebhookTypesSummary "List webhooks types")
+(def GetWebhookTypesDesc "Returns all webhook types defined")
+
+(defschema WebhookType
+  {(optional-key :id)       (describe UUID "A UUID for the type")
+   :type                    (describe NonBlankString "Webhook type")
+   (optional-key :template) (describe NonBlankString "Template for this Webhook type")})
+
+(def WebhookIdParam (describe UUID "A UUID that is used to identify the Webhook"))
+(defschema Webhook
+  {(optional-key :id) WebhookIdParam
+   :type              (describe WebhookType "Type of webhook subscription")
+   :url               (describe NonBlankString "Url to post the notification")
+   :topics            (describe [NonBlankString] "A List of topic names")})
+(defschema WebhookList
+  {:webhooks (describe [Webhook] "A List of webhooks")})
+
+(defschema Topic
+  {:id    (describe UUID "A UUID for the topic")
+   :topic (describe NonBlankString "The topic")})
+(defschema TopicList
+  {:topics (describe [Topic] "A List of topics")})
+
+(defschema WebhookTypeList
+  {:webhooktypes (describe [WebhookType] "A List of webhook types")})


### PR DESCRIPTION
Re: versioning - It seems the version is currently `2.11.6-SNAPSHOT`, and it looks like the pattern is to update to the version without `-SNAPSHOT` after merging.  Let me know if this is incorrect.  I'll have PRs open for apps and terrain pointing to version `2.11.6`