### PR TITLE
CORE-11 Import schemas and docs for bootstrap and logout endpoints

### DIFF
--- a/src/common_swagger_api/schema/apps/bootstrap.clj
+++ b/src/common_swagger_api/schema/apps/bootstrap.clj
@@ -1,0 +1,15 @@
+(ns common-swagger-api.schema.apps.bootstrap
+  (:use [common-swagger-api.schema :only [describe]]
+        [common-swagger-api.schema.apps :only [SystemId]]
+        [common-swagger-api.schema.apps.workspace :only [Workspace]]
+        [common-swagger-api.schema.webhooks :only [WebhookList]]
+        [schema.core :only [defschema]]))
+
+(defschema SystemIds
+  {:de_system_id   (describe SystemId "The internal system ID used by the Discovery Environment.")
+   :all_system_ids (describe [SystemId] "The list of system IDs available to the Discovery Environment.")})
+
+(defschema AppsBootstrapResponse
+  (merge WebhookList
+         {:system_ids (describe SystemIds "Information about system IDs available to the Discovery Environment.")
+          :workspace  (describe Workspace "Information about the user's Discovery Environment workspace.")}))

--- a/src/common_swagger_api/schema/apps/workspace.clj
+++ b/src/common_swagger_api/schema/apps/workspace.clj
@@ -1,0 +1,13 @@
+(ns common-swagger-api.schema.apps.workspace
+  (:use [common-swagger-api.schema :only [describe]]
+        [schema.core :only [defschema optional-key]])
+  (:import (java.util UUID)))
+
+(def WorkspaceId (describe UUID "The workspace ID."))
+
+(defschema Workspace
+  {:id               WorkspaceId
+   :user_id          (describe UUID "The user's internal ID.")
+   :root_category_id (describe UUID "The ID of the user's root app category.")
+   :is_public        (describe Boolean "Indicates whether the workspace is public.")
+   :new_workspace    (describe Boolean "Indicates whether the workspace was just created.")})

--- a/src/common_swagger_api/schema/data/navigation.clj
+++ b/src/common_swagger_api/schema/data/navigation.clj
@@ -1,0 +1,8 @@
+(ns common-swagger-api.schema.data.navigation
+  (:use [common-swagger-api.schema :only [describe]])
+  (:require [schema.core :as s]))
+
+(s/defschema UserBasePaths
+  {:user_home_path  (describe String "The absolute path to the user's home folder")
+   :user_trash_path (describe String "The absolute path to the user's trash folder")
+   :base_trash_path (describe String "The absolute path to the base trash folder")})

--- a/src/common_swagger_api/schema/oauth.clj
+++ b/src/common_swagger_api/schema/oauth.clj
@@ -1,0 +1,12 @@
+(ns common-swagger-api.schema.oauth
+  (:use [common-swagger-api.schema :only [describe doc-only]])
+  (:require [schema.core :as s]))
+
+(s/defschema RedirectUris
+  {(describe s/Keyword "The name of the API")
+   (describe String "The redirect URI")})
+
+(s/defschema RedirectUrisDoc
+  {:api-name (describe String "The redirect URI.")})
+
+(def RedirectUrisResponse (doc-only RedirectUris RedirectUrisDoc))

--- a/src/common_swagger_api/schema/sessions.clj
+++ b/src/common_swagger_api/schema/sessions.clj
@@ -9,3 +9,7 @@
 (defschema LoginResponse
   {:login_time    (describe Long "Login time as milliseconds since the epoch.")
    :auth_redirect RedirectUrisResponse})
+
+(defschema LogoutParams
+  (merge IPAddrParam
+         {:login-time (describe Long "The login time returned by `POST /users/login` or `/bootstrap`.")}))

--- a/src/common_swagger_api/schema/sessions.clj
+++ b/src/common_swagger_api/schema/sessions.clj
@@ -1,0 +1,11 @@
+(ns common-swagger-api.schema.sessions
+  (:use [common-swagger-api.schema :only [describe]]
+        [common-swagger-api.schema.oauth :only [RedirectUrisResponse]]
+        [schema.core :only [defschema]]))
+
+(defschema IPAddrParam
+  {:ip-address (describe String "The IP address of the requesting user, for matching login to logout requests.")})
+
+(defschema LoginResponse
+  {:login_time    (describe Long "Login time as milliseconds since the epoch.")
+   :auth_redirect RedirectUrisResponse})

--- a/src/common_swagger_api/schema/sessions.clj
+++ b/src/common_swagger_api/schema/sessions.clj
@@ -3,6 +3,9 @@
         [common-swagger-api.schema.oauth :only [RedirectUrisResponse]]
         [schema.core :only [defschema]]))
 
+(def LogoutSummary "Record a User Logout")
+(def LogoutDocs "This service records the fact that the user logged out.")
+
 (defschema IPAddrParam
   {:ip-address (describe String "The IP address of the requesting user, for matching login to logout requests.")})
 

--- a/src/common_swagger_api/schema/webhooks.clj
+++ b/src/common_swagger_api/schema/webhooks.clj
@@ -18,11 +18,13 @@
    (optional-key :template) (describe NonBlankString "Template for this Webhook type")})
 
 (def WebhookIdParam (describe UUID "A UUID that is used to identify the Webhook"))
+
 (defschema Webhook
   {(optional-key :id) WebhookIdParam
    :type              (describe WebhookType "Type of webhook subscription")
    :url               (describe NonBlankString "Url to post the notification")
    :topics            (describe [NonBlankString] "A List of topic names")})
+
 (defschema WebhookList
   {:webhooks (describe [Webhook] "A List of webhooks")})
 


### PR DESCRIPTION
This PR will:
* Import apps `/bootstrap` endpoint schemas.
* Import `/users/login` schemas from `apps.routes.schemas.user` into `common-swagger-api.schema.sessions`, and from `apps.routes.schemas.oauth` into `common-swagger-api.schema.oauth`.
* Import `/navigation/base-paths` schemas from `data-info.routes.schemas.navigation` into `common-swagger-api.schema.data.navigation`.
* Import `LogoutParams` schema from `apps.routes.schemas.user` into `common-swagger-api.schema.sessions`.
* Import `/users/logout` endpoint docs from `apps.routes.users` into `common-swagger-api.schema.sessions`.

These schemas and docs are required for documenting the `/bootstrap` and `/users/logout` endpoints in the `terrain` service.