### PR TITLE
CORE-11 Import schemas and docs for /admin/apps endpoints.

### DIFF
--- a/resources/docs/apps/admin/app-label-update.md
+++ b/resources/docs/apps/admin/app-label-update.md
@@ -1,0 +1,8 @@
+This service is capable of updating high-level information of an App, including `deleted` and `disabled` flags,
+as well as just the labels within a single-step app that has already been made available for public use.
+The app's name must not duplicate the name of any other app (visible to the requesting user)
+under the same categories as this app.
+
+**Note**: Although this endpoint accepts all App Group and Parameter fields within the 'groups' array,
+only their `description`, `label`, and `display` (only in parameter arguments)
+fields will be processed and updated by this endpoint.

--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -67,15 +67,17 @@
   (sets/union apps/AppSearchValidSortFields
               AdminAppListingJobStatsKeys))
 
-(def AppSubsets (enum :public :private :all))
+(def AppSubsetDocs "The subset of apps to search.")
+(def AppSubsetOptionalKey (optional-key :app-subset))
+(def AppSubsets [:public :private :all])
 
 (defschema AdminAppSearchParams
   (merge apps/AppSearchParams
          {SortFieldOptionalKey
           (describe (apply enum AdminAppSearchValidSortFields) SortFieldDocs)
 
-          (optional-key :app-subset)
-          (describe AppSubsets "The subset of apps to search." :default :public)}))
+          AppSubsetOptionalKey
+          (describe (apply enum AppSubsets) AppSubsetDocs :default :public)}))
 
 (defschema AdminAppDetails
   (merge apps/AppDetails

--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -11,6 +11,32 @@
             [common-swagger-api.schema.apps :as apps])
   (:import [java.util Date]))
 
+(def AdminAppPatchSummary "Update App Details and Labels")
+
+(def AppDeleteDocs
+  "An app can be marked as deleted in the DE without being completely removed from the database using this service.
+   This endpoint is the same as the non-admin endpoint,
+   except an error is not returned if the user does not own the App.")
+
+(def AppDetailsDocs "This service allows administrative users to view detailed information about private apps.")
+(def AppDocumentationAddDocs "This service is used by DE administrators to add documentation for a single App.")
+(def AppDocumentationUpdateDocs "This service is used by DE administrators to update documentation for a single App.")
+
+(def AppIntegrationDataUpdateSummary "Update the Integration Data Record for an App")
+(def AppIntegrationDataUpdateDocs
+  "This service allows administrators to change the integration data record associated with an app.")
+
+(def AppListingDocs
+  "This service allows admins to list all public apps, including apps listed under the `Trash` category:
+   deleted public apps and private apps that are 'orphaned' (not categorized in any user's workspace).
+   If the `search` parameter is included, then the results are filtered by the App name, description,
+   integrator's name, tool name, or category name the app is under.")
+
+(def AppShredderSummary "Permanently Deleting Apps")
+(def AppShredderDocs
+  "This service physically removes an App from the database,
+   which allows administrators to completely remove Apps that are causing problems.")
+
 (defschema AdminAppListingJobStats
   (merge apps/AppListingJobStats
          {:job_count
@@ -65,4 +91,5 @@
              (optional-key :references) apps/AppReferencesParam
              (optional-key :deleted) apps/AppDeletedParam
              (optional-key :disabled) apps/AppDisabledParam
-             apps/OptionalGroupsKey (describe [apps/AppGroup] apps/GroupListDocs))))
+             apps/OptionalGroupsKey (describe [apps/AppGroup] apps/GroupListDocs))
+      (describe "The App to update.")))

--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -1,0 +1,68 @@
+(ns common-swagger-api.schema.apps.admin.apps
+  (:use [common-swagger-api.schema
+         :only [->optional-param
+                optional-key->keyword
+                describe
+                PagingParams
+                SortFieldDocs
+                SortFieldOptionalKey]]
+        [schema.core :only [defschema enum optional-key]])
+  (:require [clojure.set :as sets]
+            [common-swagger-api.schema.apps :as apps])
+  (:import [java.util Date]))
+
+(defschema AdminAppListingJobStats
+  (merge apps/AppListingJobStats
+         {:job_count
+          (describe Long "The number of times this app has run")
+
+          :job_count_failed
+          (describe Long "The number of times this app has run to `Failed` status")
+
+          (optional-key :last_used)
+          (describe Date "The start date this app was last run")}))
+
+(defschema AdminAppListingDetail
+  (merge apps/AppListingDetail
+         {(optional-key :job_stats)
+          (describe AdminAppListingJobStats apps/AppListingJobStatsDocs)}))
+
+(defschema AdminAppListing
+  (merge apps/AppListing
+         {:apps (describe [AdminAppListingDetail] "A listing of App details")}))
+
+(def AdminAppListingJobStatsKeys
+  (->> AdminAppListingJobStats
+       keys
+       (map optional-key->keyword)
+       set))
+
+(def AdminAppSearchValidSortFields
+  (sets/union apps/AppSearchValidSortFields
+              AdminAppListingJobStatsKeys))
+
+(def AppSubsets (enum :public :private :all))
+
+(defschema AdminAppSearchParams
+  (merge apps/AppSearchParams
+         {SortFieldOptionalKey
+          (describe (apply enum AdminAppSearchValidSortFields) SortFieldDocs)
+
+          (optional-key :app-subset)
+          (describe AppSubsets "The subset of apps to search." :default :public)}))
+
+(defschema AdminAppDetails
+  (merge apps/AppDetails
+         {(optional-key :job_stats)
+          (describe AdminAppListingJobStats apps/AppListingJobStatsDocs)}))
+
+(defschema AdminAppPatchRequest
+  (-> apps/AppBase
+      (->optional-param :id)
+      (->optional-param :name)
+      (->optional-param :description)
+      (assoc (optional-key :wiki_url) apps/AppDocUrlParam
+             (optional-key :references) apps/AppReferencesParam
+             (optional-key :deleted) apps/AppDeletedParam
+             (optional-key :disabled) apps/AppDisabledParam
+             apps/OptionalGroupsKey (describe [apps/AppGroup] apps/GroupListDocs))))

--- a/src/common_swagger_api/schema/apps/admin/categories.clj
+++ b/src/common_swagger_api/schema/apps/admin/categories.clj
@@ -4,6 +4,10 @@
         [schema.core :only [defschema]])
   (:require [common-swagger-api.schema.apps.categories :as categories-schema]))
 
+(def AppCategorizationSummary "Categorize Apps")
+(def AppCategorizationDocs
+  "This endpoint is used by the Admin interface to add or move Apps to into multiple Categories.")
+
 (defschema AppCategoryIdList
   {:category_ids (describe [categories-schema/AppCategoryId] "A List of App Category identifiers")})
 
@@ -13,4 +17,5 @@
           :app_id    (describe String "The ID of the App to be Categorized")}))
 
 (defschema AppCategorizationRequest
-  {:categories (describe [AppCategorization] "Apps and the Categories they should be listed under")})
+  (-> {:categories (describe [AppCategorization] "Apps and the Categories they should be listed under")}
+      (describe "An App Categorization Request.")))

--- a/src/common_swagger_api/schema/apps/admin/categories.clj
+++ b/src/common_swagger_api/schema/apps/admin/categories.clj
@@ -1,0 +1,16 @@
+(ns common-swagger-api.schema.apps.admin.categories
+  (:use [common-swagger-api.schema :only [describe]]
+        [common-swagger-api.schema.apps :only [SystemId]]
+        [schema.core :only [defschema]])
+  (:require [common-swagger-api.schema.apps.categories :as categories-schema]))
+
+(defschema AppCategoryIdList
+  {:category_ids (describe [categories-schema/AppCategoryId] "A List of App Category identifiers")})
+
+(defschema AppCategorization
+  (merge AppCategoryIdList
+         {:system_id SystemId
+          :app_id    (describe String "The ID of the App to be Categorized")}))
+
+(defschema AppCategorizationRequest
+  {:categories (describe [AppCategorization] "Apps and the Categories they should be listed under")})

--- a/src/common_swagger_api/schema/integration_data.clj
+++ b/src/common_swagger_api/schema/integration_data.clj
@@ -3,6 +3,8 @@
         [schema.core :only [defschema optional-key]])
   (:import [java.util UUID]))
 
+(def IntegrationDataIdPathParam (describe UUID "A UUID that is used to identify the integration data record"))
+
 (defschema IntegrationDataUpdate
   {:email
    (describe NonBlankString "The user's email address.")


### PR DESCRIPTION
This PR will import `/admin/apps` endpoint docs from `apps.routes.admin`, and schemas from `apps.routes.schemas.app` to `common-swagger-api.schema.apps.admin.apps`, and from `apps.routes.schemas.app.category` to `common-swagger-api.schema.apps.admin.categories`.

It will also refactor the `:app-subset` field of the `AdminAppSearchParams` schema, since the `terrain` service needs to convert the `AppSubsets` keywords into strings, then rebuild the docs for this field in its endpoint docs.