### PR TITLE
CORE-11 Import docs and schemas for /admin/reference-genomes endpoints

### DIFF
--- a/src/common_swagger_api/schema/apps/admin/reference_genomes.clj
+++ b/src/common_swagger_api/schema/apps/admin/reference_genomes.clj
@@ -1,0 +1,14 @@
+(ns common-swagger-api.schema.apps.admin.reference-genomes
+  (:use [common-swagger-api.schema :only [->optional-param describe]]
+        [common-swagger-api.schema.apps.reference-genomes :only [ReferenceGenome]]
+        [schema.core :only [defschema optional-key]]))
+
+(defschema ReferenceGenomeDeletionParams
+  {(optional-key :permanent)
+   (describe Boolean "If true, completely remove the reference genome from the database.")})
+
+(defschema ReferenceGenomeRequest
+  (-> ReferenceGenome
+      (->optional-param :id)
+      (->optional-param :created_by)
+      (->optional-param :last_modified_by)))

--- a/src/common_swagger_api/schema/apps/admin/reference_genomes.clj
+++ b/src/common_swagger_api/schema/apps/admin/reference_genomes.clj
@@ -3,6 +3,20 @@
         [common-swagger-api.schema.apps.reference-genomes :only [ReferenceGenome]]
         [schema.core :only [defschema optional-key]]))
 
+(def ReferenceGenomeAddSummary "Add a Reference Genome")
+(def ReferenceGenomeAddDocs
+  "This endpoint adds a Reference Genome to the Discovery Environment.")
+
+(def ReferenceGenomeDeleteSummary "Delete a Reference Genome")
+(def ReferenceGenomeDeleteDocs
+  "A Reference Genome can be marked as deleted in the DE without being completely removed from the database using this service.
+   **Note**: an attempt to delete a Reference Genome that is already marked as deleted is treated as a no-op rather than an error condition.
+   If the Reference Genome doesn't exist in the database at all, however, then that is treated as an error condition.")
+
+(def ReferenceGenomeUpdateSummary "Update a Reference Genome")
+(def ReferenceGenomeUpdateDocs
+  "This endpoint modifies the `name`, `path`, and `deleted` fields of a Reference Genome in the Discovery Environment.")
+
 (defschema ReferenceGenomeDeletionParams
   {(optional-key :permanent)
    (describe Boolean "If true, completely remove the reference genome from the database.")})
@@ -12,3 +26,11 @@
       (->optional-param :id)
       (->optional-param :created_by)
       (->optional-param :last_modified_by)))
+
+(defschema ReferenceGenomeAddRequest
+  (-> ReferenceGenomeRequest
+      (describe "The Reference Genome to add.")))
+
+(defschema ReferenceGenomeUpdateRequest
+  (-> ReferenceGenomeRequest
+      (describe "The Reference Genome fields to update.")))


### PR DESCRIPTION
This PR will import `/admin/reference-genomes` endpoint docs and admin schemas from `apps.routes.schemas.reference-genome` into `common-swagger-api.schema.apps.admin.reference-genomes`.