### PR TITLE
CORE-11 Update AppSearchParams docs and schemas for use in terrain.

### DIFF
--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -547,6 +547,12 @@
          {SortFieldOptionalKey
           (describe (apply enum AppListingValidSortFields) SortFieldDocs)}))
 
+(def AppJobStatsStartDateOptionalParam (optional-key :start_date))
+(def AppJobStatsStartDateParamDocs "Filters out the app stats before this start date")
+
+(def AppJobStatsEndDateOptionalParam (optional-key :end_date))
+(def AppJobStatsEndDateParamDocs "Filters out the apps stats after this end date")
+
 (defschema AppSearchParams
   (merge PagingParams
          AppFilterParams
@@ -554,11 +560,11 @@
           (describe String
                     "The pattern to match in an App's Name, Description, Integrator Name, or Tool Name.")
 
-          (optional-key :start_date)
-          (describe Date "Filters out the app stats before this start date")
+          AppJobStatsStartDateOptionalParam
+          (describe Date AppJobStatsStartDateParamDocs)
 
-          (optional-key :end_date)
-          (describe Date "Filters out the apps stats after this end date")
+          AppJobStatsEndDateOptionalParam
+          (describe Date AppJobStatsEndDateParamDocs)
 
           SortFieldOptionalKey
           (describe (apply enum AppSearchValidSortFields) SortFieldDocs)}))


### PR DESCRIPTION
This PR will refactor App job stats start/end date params and docs so that terrain can rebuild these as Strings, since `Date` query params are parsed into invalid string formats (`Tue Dec 30 17:00:00 MST 1969` for example) when forwarded to the apps service.