### PR TITLE
CORE-63: add extra info to AdminAppPatchRequest schema

### DIFF
--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -84,12 +84,18 @@
          {(optional-key :job_stats)
           (describe AdminAppListingJobStats apps/AppListingJobStatsDocs)}))
 
+(defschema AppExtraInfo
+  {:htcondor
+   {:extra_requirements
+    (describe String "A set of additional requirements to add to the HTCondor submit file")}})
+
 (defschema AdminAppPatchRequest
   (-> apps/AppBase
       (->optional-param :id)
       (->optional-param :name)
       (->optional-param :description)
-      (assoc (optional-key :wiki_url) apps/AppDocUrlParam
+      (assoc (optional-key :extra) AppExtraInfo
+             (optional-key :wiki_url) apps/AppDocUrlParam
              (optional-key :references) apps/AppReferencesParam
              (optional-key :deleted) apps/AppDeletedParam
              (optional-key :disabled) apps/AppDisabledParam


### PR DESCRIPTION
(n.b. won't merge this until everything else as far as endpoint changes is ready, but I figured I could get this first step up since this stuff moved out of the apps service and into this library)

This adds the `AppExtraInfo` schema which, at present, only includes extra requirements for HTCondor, and adds that to the `AdminAppPatchRequest` schema.

Steps in other repositories and this one (separately) that need doing/are in progress include:
* handling this extra parameter in the apps backend (in progress)
* adding or amending an endpoint to return this value so it can be displayed in Belphegor (not yet in progress, we discussed adding it to the admin app details endpoint; the changes will span this as well as the apps repo)