### PR TITLE
CORE-63: add app extra info to AdminAppDetails too

### DIFF
--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -84,12 +84,18 @@
          {(optional-key :job_stats)
           (describe AdminAppListingJobStats apps/AppListingJobStatsDocs)}))
 
+(defschema AppExtraInfo
+  {:htcondor
+   {:extra_requirements
+    (describe String "A set of additional requirements to add to the HTCondor submit file")}})
+
 (defschema AdminAppPatchRequest
   (-> apps/AppBase
       (->optional-param :id)
       (->optional-param :name)
       (->optional-param :description)
-      (assoc (optional-key :wiki_url) apps/AppDocUrlParam
+      (assoc (optional-key :extra) AppExtraInfo
+             (optional-key :wiki_url) apps/AppDocUrlParam
              (optional-key :references) apps/AppReferencesParam
              (optional-key :deleted) apps/AppDeletedParam
              (optional-key :disabled) apps/AppDisabledParam

--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -79,15 +79,18 @@
           AppSubsetOptionalKey
           (describe (apply enum AppSubsets) AppSubsetDocs :default :public)}))
 
-(defschema AdminAppDetails
-  (merge apps/AppDetails
-         {(optional-key :job_stats)
-          (describe AdminAppListingJobStats apps/AppListingJobStatsDocs)}))
-
 (defschema AppExtraInfo
   {:htcondor
    {:extra_requirements
     (describe String "A set of additional requirements to add to the HTCondor submit file")}})
+
+(defschema AdminAppDetails
+  (merge apps/AppDetails
+         {(optional-key :job_stats)
+          (describe AdminAppListingJobStats apps/AppListingJobStatsDocs)
+
+          (optional-key :extra)
+          AppExtraInfo}))
 
 (defschema AdminAppPatchRequest
   (-> apps/AppBase


### PR DESCRIPTION
This includes the changes from #36 as well. May not even need an approval to merge, since this is quite simple.