### PR TITLE
CORE-11 Import schemas and docs for /admin/tools endpoints

### DIFF
--- a/resources/docs/tools/admin/tool-update.md
+++ b/resources/docs/tools/admin/tool-update.md
@@ -1,0 +1,11 @@
+This service updates a Tool definition in the DE.
+
+**Note**: If the `container` object is omitted in the request, then existing container settings will not be modified,
+but if the `container` object is present in the request, then all container settings must be included in it.
+Any existing settings not included in the request's `container` object will be removed.
+
+#### ⚠️Danger Zone⚠️
+
+Do not update container settings that are in use by tools in public apps
+unless it is certain the new container settings will not break reproducibility for those apps.
+If required, the `overwrite-public` flag may be used to update these settings for public tools.

--- a/resources/docs/tools/admin/tools-import.md
+++ b/resources/docs/tools/admin/tools-import.md
@@ -1,0 +1,12 @@
+This service adds new Tools to the DE.
+
+#### ⚠️Warning: Use caution with Entrypoint settings!
+
+Do not add a tool without an `entrypoint` setting if its Docker image also does not have a default `ENTRYPOINT`.
+If a tool like this is required, then its `network_mode` setting should be set to `none`
+to contain any risky scripts run by this tool.
+
+#### ⚠️Warning: Use caution with Volumes settings!
+
+Do not add `volumes` or `volumes_from` settings to tools
+unless it is certain that tool is authorized to access that data.

--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -3,6 +3,8 @@
          :only [->optional-param
                 optional-key->keyword
                 describe
+                CommonResponses
+                ErrorResponseNotFound
                 PagingParams
                 SortFieldDocs
                 SortFieldOptionalKey]]
@@ -104,3 +106,10 @@
              (optional-key :disabled) apps/AppDisabledParam
              apps/OptionalGroupsKey (describe [apps/AppGroup] apps/GroupListDocs))
       (describe "The App to update.")))
+
+(defschema ToolAdminAppListingResponses
+  (merge CommonResponses
+         {200 {:schema      AdminAppListing
+               :description "The listing of Apps using the given Tool."}
+          404 {:schema      ErrorResponseNotFound
+               :description "The `tool-id` does not exist."}}))

--- a/src/common_swagger_api/schema/tools/admin.clj
+++ b/src/common_swagger_api/schema/tools/admin.clj
@@ -1,0 +1,23 @@
+(ns common-swagger-api.schema.tools.admin
+  (:use [common-swagger-api.schema :only [->optional-param describe]]
+        [schema.core :only [defschema optional-key]])
+  (:require [common-swagger-api.schema.tools :as schema])
+  (:import [java.util UUID]))
+
+(defschema ToolIdsList
+  {:tool_ids (describe [UUID] "A List of Tool IDs")})
+
+(defschema ToolUpdateParams
+  {(optional-key :overwrite-public)
+   (describe Boolean "Flag to force container settings updates of public tools.")})
+
+(defschema ToolsImportRequest
+  {:tools (describe [schema/ToolImportRequest] "zero or more Tool definitions")})
+
+(defschema ToolUpdateRequest
+  (-> schema/ToolImportRequest
+      (->optional-param :name)
+      (->optional-param :version)
+      (->optional-param :type)
+      (->optional-param :implementation)
+      (->optional-param :container)))

--- a/src/common_swagger_api/schema/tools/admin.clj
+++ b/src/common_swagger_api/schema/tools/admin.clj
@@ -1,8 +1,35 @@
 (ns common-swagger-api.schema.tools.admin
-  (:use [common-swagger-api.schema :only [->optional-param describe]]
+  (:use [common-swagger-api.schema
+         :only [->optional-param
+                describe
+                CommonResponses
+                ErrorResponseExists
+                ErrorResponseNotFound
+                ErrorResponseNotWritable]]
         [schema.core :only [defschema optional-key]])
   (:require [common-swagger-api.schema.tools :as schema])
   (:import [java.util UUID]))
+
+(def ToolDeleteSummary "Delete a Tool")
+(def ToolDeleteDocs
+  "Deletes a tool, as long as it is not in use by any apps.")
+
+(def ToolDetailsDocs "This endpoint returns the details for one tool.")
+
+(def ToolsImportSummary "Add new Tools.")
+
+(def ToolIntegrationUpdateSummary "Update the Integration Data Record for a Tool")
+(def ToolIntegrationUpdateDocs
+  "This service allows administrators to change the integration data record associated with a tool.")
+
+(def ToolListingDocs "This endpoint allows admins to get a listing of all Tools.")
+
+(def ToolPublishSummary "Make a Private Tool Public")
+(def ToolPublishDocs
+  "This service makes a Private Tool public and available to all users.
+   The request body fields are optional and allow the admin to make updates to the tool in the same request.")
+
+(def ToolUpdateSummary "Update a Tool")
 
 (defschema ToolIdsList
   {:tool_ids (describe [UUID] "A List of Tool IDs")})
@@ -12,7 +39,8 @@
    (describe Boolean "Flag to force container settings updates of public tools.")})
 
 (defschema ToolsImportRequest
-  {:tools (describe [schema/ToolImportRequest] "zero or more Tool definitions")})
+  (-> {:tools (describe [schema/ToolImportRequest] "zero or more Tool definitions")}
+      (describe "The Tools to import.")))
 
 (defschema ToolUpdateRequest
   (-> schema/ToolImportRequest
@@ -20,4 +48,45 @@
       (->optional-param :version)
       (->optional-param :type)
       (->optional-param :implementation)
-      (->optional-param :container)))
+      (->optional-param :container)
+      (describe "The Tool to update.")))
+
+(defschema ToolDeleteResponses
+  (merge CommonResponses
+         {200 {:description "The Tool was successfully deleted."}
+          400 {:schema      ErrorResponseNotWritable
+               :description "The Tool is already in use by apps and could not be deleted."}
+          404 {:schema      ErrorResponseNotFound
+               :description "A Tool with the given `tool-id` does not exist."}}))
+
+(defschema ToolDetailsResponses
+  (merge CommonResponses
+         {200 {:schema      schema/ToolDetails
+               :description "The Tool details."}
+          404 {:schema      ErrorResponseNotFound
+               :description "The `tool-id` does not exist."}}))
+
+(defschema ToolsImportResponses
+  (merge CommonResponses
+         {200 {:schema      ToolIdsList
+               :description "A list of the new Tool IDs."}
+          400 {:schema      ErrorResponseExists
+               :description "A Tool with the given `name` already exists."}}))
+
+(defschema ToolPublishResponses
+  (merge CommonResponses
+         {200 {:schema      schema/ToolDetails
+               :description "The Tool details."}
+          400 {:schema      ErrorResponseNotWritable
+               :description "The Tool is already public."}
+          404 {:schema      ErrorResponseNotFound
+               :description "The `tool-id` does not exist."}}))
+
+(defschema ToolUpdateResponses
+  (merge CommonResponses
+         {200 {:schema      schema/ToolDetails
+               :description "The Tool details."}
+          400 {:schema      ErrorResponseNotWritable
+               :description "The Tool is in use by public apps its container could not be updated."}
+          404 {:schema      ErrorResponseNotFound
+               :description "The `tool-id` does not exist."}}))


### PR DESCRIPTION
This PR will import the schemas and docs for `/admin/tools` endpoints from `apps.routes.tools` and `apps.routes.schemas.tool` into `common-swagger-api.schema.tools.admin`.