### PR TITLE
CORE-9 Import schemas and docs for /navigation endpoints

### DIFF
--- a/src/common_swagger_api/schema/data.clj
+++ b/src/common_swagger_api/schema/data.clj
@@ -1,7 +1,10 @@
 (ns common-swagger-api.schema.data
-  (:use [common-swagger-api.schema :only [describe NonBlankString]])
+  (:use [clojure-commons.error-codes]
+        [common-swagger-api.schema :only [describe NonBlankString]])
   (:require [schema.core :as s])
   (:import [java.util UUID]))
+
+(def CommonErrorCodeResponses [ERR_UNCHECKED_EXCEPTION ERR_SCHEMA_VALIDATION])
 
 (def DataIdPathParam (describe UUID "The UUID assigned to the file or folder"))
 

--- a/src/common_swagger_api/schema/data/navigation.clj
+++ b/src/common_swagger_api/schema/data/navigation.clj
@@ -1,7 +1,18 @@
 (ns common-swagger-api.schema.data.navigation
-  (:use [common-swagger-api.schema :only [describe]]
+  (:use [clojure-commons.error-codes]
+        [common-swagger-api.schema :only [describe CommonResponses ErrorResponse ErrorResponseUnchecked]]
+        [common-swagger-api.schema.data :as data-schema]
         [common-swagger-api.schema.stats :as stats-schema])
   (:require [schema.core :as s]))
+
+(def NavigationRootSummary "Root Listing")
+(def NavigationRootDocs
+  "This endpoint provides a shortcut for the client to list the top-level directories
+   (e.g. the user's home directory, trash, and shared directories).")
+
+(def NavigationSummary "Directory List (Non-Recursive)")
+(def NavigationDocs
+  "Only lists subdirectories of the directory path passed into it.")
 
 (s/defschema UserBasePaths
   {:user_home_path  (describe String "The absolute path to the user's home folder")
@@ -23,3 +34,32 @@
 
 (s/defschema NavigationResponse
   {:folder FolderListing})
+
+(def NavigationRootErrorCodeResponses
+  (conj data-schema/CommonErrorCodeResponses
+        ERR_DOES_NOT_EXIST
+        ERR_NOT_READABLE
+        ERR_NOT_A_USER))
+
+(s/defschema NavigationRootErrorResponses
+  (merge ErrorResponseUnchecked
+         {:error_code (apply s/enum NavigationRootErrorCodeResponses)}))
+
+(s/defschema NavigationErrorResponses
+  (merge ErrorResponseUnchecked
+         {:error_code (apply s/enum (conj NavigationRootErrorCodeResponses
+                                          ERR_NOT_A_FOLDER))}))
+
+(s/defschema NavigationRootResponses
+  (merge CommonResponses
+         {200 {:schema      NavigationRootResponse
+               :description "The Root Listing."}
+          500 {:schema      NavigationRootErrorResponses
+               :description "Potential Error Codes returned by this endpoint."}}))
+
+(s/defschema NavigationResponses
+  (merge CommonResponses
+         {200 {:schema      NavigationResponse
+               :description "The Folder Listing."}
+          500 {:schema      NavigationErrorResponses
+               :description "Potential Error Codes returned by this endpoint."}}))

--- a/src/common_swagger_api/schema/data/navigation.clj
+++ b/src/common_swagger_api/schema/data/navigation.clj
@@ -1,8 +1,25 @@
 (ns common-swagger-api.schema.data.navigation
-  (:use [common-swagger-api.schema :only [describe]])
+  (:use [common-swagger-api.schema :only [describe]]
+        [common-swagger-api.schema.stats :as stats-schema])
   (:require [schema.core :as s]))
 
 (s/defschema UserBasePaths
   {:user_home_path  (describe String "The absolute path to the user's home folder")
    :user_trash_path (describe String "The absolute path to the user's trash folder")
    :base_trash_path (describe String "The absolute path to the base trash folder")})
+
+(s/defschema RootListing
+  (dissoc stats-schema/DataStatInfo :type))
+
+(s/defschema NavigationRootResponse
+  {:roots      [RootListing]
+   :base-paths UserBasePaths})
+
+(s/defschema FolderListing
+  (-> stats-schema/DataStatInfo
+      (dissoc :type)
+      (assoc (s/optional-key :folders)
+             (describe [(s/recursive #'FolderListing)] "Subdirectories of this directory"))))
+
+(s/defschema NavigationResponse
+  {:folder FolderListing})


### PR DESCRIPTION
This PR will import schemas from `data-info.routes.schemas.navigation`, and docs for `/navigation/root` and `/navigation/path/:zone/:path`, into `common-swagger-api.schema.data.navigation`.