### PR TITLE
CORE-63: Add app documentation to admin app details schema

### DIFF
--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -91,6 +91,9 @@
          {(optional-key :job_stats)
           (describe AdminAppListingJobStats apps/AppListingJobStatsDocs)
 
+          (optional-key :documentation)
+          (describe apps/AppDocumentation "App documentation as returned by the specific app documentation endpoints.")
+
           (optional-key :extra)
           AppExtraInfo}))
 


### PR DESCRIPTION
Should be pretty straightforward, I think.