### PR TITLE
CORE-9 Import existence endpoint schemas and docs.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,6 +12,7 @@
                  [org.cyverse/clojure-commons "3.0.3"]
                  [org.cyverse/heuristomancer "2.8.6"]
                  [org.flatland/ordered "1.5.7"]]
-  :eastwood {:linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
+  :eastwood {:exclude-namespaces [common-swagger-api.schema.data.exists]
+             :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
   :plugins [[test2junit "1.2.2"]
             [jonase/eastwood "0.3.5"]])

--- a/src/common_swagger_api/schema/data.clj
+++ b/src/common_swagger_api/schema/data.clj
@@ -9,3 +9,6 @@
 (def DataIdPathParam (describe UUID "The UUID assigned to the file or folder"))
 
 (def PermissionEnum (s/enum :read :write :own))
+
+(s/defschema Paths
+  {:paths (describe [(s/one NonBlankString "path") NonBlankString] "A list of iRODS paths")})

--- a/src/common_swagger_api/schema/data.clj
+++ b/src/common_swagger_api/schema/data.clj
@@ -5,6 +5,7 @@
   (:import [java.util UUID]))
 
 (def CommonErrorCodeResponses [ERR_UNCHECKED_EXCEPTION ERR_SCHEMA_VALIDATION])
+(def CommonErrorCodeDocs "Potential Error Codes returned by this endpoint.")
 
 (def DataIdPathParam (describe UUID "The UUID assigned to the file or folder"))
 

--- a/src/common_swagger_api/schema/data/exists.clj
+++ b/src/common_swagger_api/schema/data/exists.clj
@@ -1,0 +1,21 @@
+(ns common-swagger-api.schema.data.exists
+  (:use [common-swagger-api.schema :only [describe]])
+  (:require [schema.core :as s]))
+
+(s/defschema PathExistenceMap
+  {(describe s/Keyword "The iRODS data item's path")
+   (describe Boolean "Whether this path from the request exists")})
+
+(s/defschema ExistenceInfo
+  {:paths
+   (describe PathExistenceMap "Paths existence mapping")})
+
+;; Used only for display as documentation in Swagger UI
+(s/defschema ExistenceResponsePathsMap
+  {:/path/from/request/to/a/file/or/folder
+   (describe Boolean "Whether this path from the request exists")})
+
+;; Used only for display as documentation in Swagger UI
+(s/defschema ExistenceResponse
+  {:paths
+   (describe ExistenceResponsePathsMap "A map of paths from the request to their existence info")})

--- a/src/common_swagger_api/schema/data/exists.clj
+++ b/src/common_swagger_api/schema/data/exists.clj
@@ -1,6 +1,19 @@
 (ns common-swagger-api.schema.data.exists
-  (:use [common-swagger-api.schema :only [describe]])
-  (:require [schema.core :as s]))
+  (:use [clojure-commons.error-codes]
+        [common-swagger-api.schema
+         :only [describe
+                doc-only
+                CommonResponses
+                ErrorResponseUnchecked]])
+  (:require [common-swagger-api.schema.data :as data-schema]
+            [schema.core :as s]))
+
+(def ExistenceSummary "File and Folder Existence")
+(def ExistenceDocs
+  "This endpoint allows the caller to check for the existence of a set of files and folders.")
+
+(s/defschema ExistenceRequest
+  (describe data-schema/Paths "The paths to check for existence."))
 
 (s/defschema PathExistenceMap
   {(describe s/Keyword "The iRODS data item's path")
@@ -19,3 +32,19 @@
 (s/defschema ExistenceResponse
   {:paths
    (describe ExistenceResponsePathsMap "A map of paths from the request to their existence info")})
+
+(def ExistenceErrorCodeResponses
+  (conj data-schema/CommonErrorCodeResponses
+        ERR_NOT_A_USER
+        ERR_TOO_MANY_RESULTS))
+
+(s/defschema ExistenceErrorResponses
+  (merge ErrorResponseUnchecked
+         {:error_code (apply s/enum ExistenceErrorCodeResponses)}))
+
+(s/defschema ExistenceResponses
+  (merge CommonResponses
+         {200 {:schema      (doc-only ExistenceInfo ExistenceResponse)
+               :description "A map of paths from the request to their existence info"}
+          500 {:schema      ExistenceErrorResponses
+               :description data-schema/CommonErrorCodeDocs}}))

--- a/src/common_swagger_api/schema/data/navigation.clj
+++ b/src/common_swagger_api/schema/data/navigation.clj
@@ -1,6 +1,6 @@
 (ns common-swagger-api.schema.data.navigation
   (:use [clojure-commons.error-codes]
-        [common-swagger-api.schema :only [describe CommonResponses ErrorResponse ErrorResponseUnchecked]]
+        [common-swagger-api.schema :only [describe CommonResponses ErrorResponseUnchecked]]
         [common-swagger-api.schema.data :as data-schema]
         [common-swagger-api.schema.stats :as stats-schema])
   (:require [schema.core :as s]))
@@ -55,11 +55,11 @@
          {200 {:schema      NavigationRootResponse
                :description "The Root Listing."}
           500 {:schema      NavigationRootErrorResponses
-               :description "Potential Error Codes returned by this endpoint."}}))
+               :description data-schema/CommonErrorCodeDocs}}))
 
 (s/defschema NavigationResponses
   (merge CommonResponses
          {200 {:schema      NavigationResponse
                :description "The Folder Listing."}
           500 {:schema      NavigationErrorResponses
-               :description "Potential Error Codes returned by this endpoint."}}))
+               :description data-schema/CommonErrorCodeDocs}}))


### PR DESCRIPTION
This PR will import schemas and docs from `data-info.routes.schemas.exists` into `common-swagger-api.schema.data.exists`, along with `data-info.routes.schemas.common/Paths` into `common-swagger-api.schema.data`.