### PR TITLE
CORE-9 Import ticket endpoint schemas and docs.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,7 +12,8 @@
                  [org.cyverse/clojure-commons "3.0.3"]
                  [org.cyverse/heuristomancer "2.8.6"]
                  [org.flatland/ordered "1.5.7"]]
-  :eastwood {:exclude-namespaces [common-swagger-api.schema.data.exists]
+  :eastwood {:exclude-namespaces [common-swagger-api.schema.data.exists
+                                  common-swagger-api.schema.data.tickets]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
   :plugins [[test2junit "1.2.2"]
             [jonase/eastwood "0.3.5"]])

--- a/src/common_swagger_api/schema/data/tickets.clj
+++ b/src/common_swagger_api/schema/data/tickets.clj
@@ -1,8 +1,25 @@
 (ns common-swagger-api.schema.data.tickets
-  (:use [common-swagger-api.schema :only [describe
+  (:use [clojure-commons.error-codes]
+        [common-swagger-api.schema :only [describe
+                                          doc-only
+                                          CommonResponses
+                                          ErrorResponseUnchecked
                                           NonBlankString
                                           StandardUserQueryParams]])
-  (:require [schema.core :as s]))
+  (:require [schema.core :as s]
+            [common-swagger-api.schema.data :as data-schema]))
+
+(def AddTicketSummary "Create Tickets")
+(def AddTicketDocs
+  "This endpoint allows creating tickets for a set of provided paths.")
+
+(def DeleteTicketSummary "Delete Tickets")
+(def DeleteTicketDocs
+  "This endpoint deletes the provided set of tickets.")
+
+(def ListTicketSummary "List Tickets")
+(def ListTicketDocs
+  "This endpoint lists tickets for a set of provided paths.")
 
 (s/defschema AddTicketQueryParams
   {(s/optional-key :mode)
@@ -61,3 +78,47 @@
 (s/defschema DeleteTicketsResponse
   (assoc Tickets
    :user (describe NonBlankString "The user performing the request.")))
+
+(def TicketCommonErrorCodes
+  (conj data-schema/CommonErrorCodeResponses
+        ERR_TOO_MANY_RESULTS
+        ERR_DOES_NOT_EXIST
+        ERR_NOT_A_USER))
+
+(s/defschema AddTicketErrorResponses
+  (merge ErrorResponseUnchecked
+         {:error_code (apply s/enum (conj TicketCommonErrorCodes
+                                          ERR_NOT_WRITEABLE))}))
+
+(s/defschema AddTicketResponses
+  (merge CommonResponses
+         {200 {:schema      AddTicketResponse
+               :description "Create Tickets Response."}
+          500 {:schema      AddTicketErrorResponses
+               :description data-schema/CommonErrorCodeDocs}}))
+
+(s/defschema ListTicketErrorResponses
+  (merge ErrorResponseUnchecked
+         {:error_code (apply s/enum (conj TicketCommonErrorCodes
+                                          ERR_NOT_READABLE))}))
+
+(s/defschema ListTicketResponses
+  (merge CommonResponses
+         {200 {:schema      (doc-only ListTicketsResponse ListTicketsDocumentation)
+               :description "List Tickets Response."}
+          500 {:schema      ListTicketErrorResponses
+               :description data-schema/CommonErrorCodeDocs}}))
+
+(s/defschema DeleteTicketErrorResponses
+  (merge ErrorResponseUnchecked
+         {:error_code (apply s/enum (conj data-schema/CommonErrorCodeResponses
+                                          ERR_NOT_WRITEABLE
+                                          ERR_TICKET_DOES_NOT_EXIST
+                                          ERR_NOT_A_USER))}))
+
+(s/defschema DeleteTicketResponses
+  (merge CommonResponses
+         {200 {:schema      DeleteTicketsResponse
+               :description "Delete Tickets Response."}
+          500 {:schema      DeleteTicketErrorResponses
+               :description data-schema/CommonErrorCodeDocs}}))

--- a/src/common_swagger_api/schema/data/tickets.clj
+++ b/src/common_swagger_api/schema/data/tickets.clj
@@ -21,10 +21,14 @@
 (def ListTicketDocs
   "This endpoint lists tickets for a set of provided paths.")
 
+(def ModeParamOptionalKey (s/optional-key :mode))
+(def ModeParamValues [:read :write])
+(def ModeParamDocs
+  "Whether the created tickets allow `write` or `read` only access. Default is `read` only.")
+
 (s/defschema AddTicketQueryParams
-  {(s/optional-key :mode)
-   (describe (s/enum :read :write)
-             "Whether the created tickets allow `write` or `read` only access. Default is `read` only.")
+  {ModeParamOptionalKey
+   (describe (apply s/enum ModeParamValues) ModeParamDocs)
 
    (s/optional-key :uses-limit)
    (describe Long "Sets the `uses-limit` of the created tickets, when provided")

--- a/src/common_swagger_api/schema/data/tickets.clj
+++ b/src/common_swagger_api/schema/data/tickets.clj
@@ -1,0 +1,63 @@
+(ns common-swagger-api.schema.data.tickets
+  (:use [common-swagger-api.schema :only [describe
+                                          NonBlankString
+                                          StandardUserQueryParams]])
+  (:require [schema.core :as s]))
+
+(s/defschema AddTicketQueryParams
+  {(s/optional-key :mode)
+   (describe (s/enum :read :write)
+             "Whether the created tickets allow `write` or `read` only access. Default is `read` only.")
+
+   (s/optional-key :uses-limit)
+   (describe Long "Sets the `uses-limit` of the created tickets, when provided")
+
+   (s/optional-key :file-write-limit)
+   (describe Long "Sets the `file-write-limit` of the created tickets, when provided (10 by default)")
+
+   :public (describe Boolean "Whether the created tickets should be made public")
+
+   (s/optional-key :for-job)
+   (describe Boolean "Indicates whether the tickets are being created for an analysis")})
+
+(s/defschema DeleteTicketQueryParams
+  {(s/optional-key :for-job)
+   (describe Boolean "Indicates whether the tickets being deleted were created for an analysis")})
+
+(s/defschema TicketDefinition
+  {:path (describe NonBlankString "The iRODS path for the ticket")
+   :ticket-id (describe NonBlankString "The ID of the ticket. Usually, but not always, a UUID.")
+   :download-url (describe NonBlankString "The URL for downloading the file associated with this ticket.")
+   :download-page-url (describe NonBlankString "The URL for managing this ticket, getting links, seeing metadata, etc.")})
+
+(s/defschema AddTicketResponse
+  {:user
+   (describe NonBlankString "The user performing the request.")
+
+   :tickets
+   (describe [TicketDefinition] "The tickets created")})
+
+(s/defschema ListTicketsResponseMap
+  {(describe s/Keyword "The iRODS data item's path")
+   (describe [TicketDefinition] "The tickets for this path")})
+
+(s/defschema ListTicketsResponse
+  {:tickets
+   (describe ListTicketsResponseMap "Map of tickets")})
+
+;; used only for documentation
+(s/defschema ListTicketsPathsMap
+  {:/path/from/request/to/a/file/or/folder
+   (describe [TicketDefinition] "The tickets for this path")})
+
+;; used only for documentation
+(s/defschema ListTicketsDocumentation
+  {:tickets
+   (describe [ListTicketsPathsMap] "the tickets")})
+
+(s/defschema Tickets
+  {:tickets (describe [NonBlankString] "A list of ticket IDs")})
+
+(s/defschema DeleteTicketsResponse
+  (assoc Tickets
+   :user (describe NonBlankString "The user performing the request.")))


### PR DESCRIPTION
This PR will import schemas and docs from `data-info.routes.schemas.tickets` and `data-info.routes.tickets` into `common-swagger-api.schema.data.tickets`.