### PR TITLE
CORE-9 Import stat-gatherer schemas and docs.

### DIFF
--- a/src/common_swagger_api/schema/data.clj
+++ b/src/common_swagger_api/schema/data.clj
@@ -1,7 +1,8 @@
 (ns common-swagger-api.schema.data
   (:use [clojure-commons.error-codes]
         [common-swagger-api.schema :only [describe NonBlankString]])
-  (:require [schema.core :as s])
+  (:require [schema.core :as s]
+            [schema-tools.core :as st])
   (:import [java.util UUID]))
 
 (def CommonErrorCodeResponses [ERR_UNCHECKED_EXCEPTION ERR_SCHEMA_VALIDATION])
@@ -13,3 +14,14 @@
 
 (s/defschema Paths
   {:paths (describe [(s/one NonBlankString "path") NonBlankString] "A list of iRODS paths")})
+
+(s/defschema OptionalPaths
+  {(s/optional-key :paths) (describe [NonBlankString] "A list of iRODS paths")})
+
+(s/defschema DataIds
+  {:ids (describe [UUID] "A list of iRODS data-object UUIDs")})
+
+(s/defschema OptionalPathsOrDataIds
+  (-> (merge DataIds OptionalPaths)
+      st/optional-keys
+      (describe "The path or data ids of the data objects to gather status information on.")))

--- a/src/common_swagger_api/schema/stats.clj
+++ b/src/common_swagger_api/schema/stats.clj
@@ -9,21 +9,20 @@
 (def DataItemPathParam (describe NonBlankString "The IRODS paths to this data item"))
 
 (s/defschema StatQueryParams
-  (assoc StandardUserQueryParams
-    (s/optional-key :validation-behavior)
-    (describe PermissionEnum "What level of permissions on the queried files should be validated?")))
+  {(s/optional-key :validation-behavior)
+   (describe PermissionEnum "What level of permissions on the queried files should be validated?")})
 
 (s/defschema FilteredStatQueryParams
-  (assoc StatQueryParams
-    (s/optional-key :filter-include)
-    (describe String (str "Comma-separated list of keys to generate and return in each stat object. "
-                          "Defaults to all keys. If both this and filter-exclude are provided, "
-                          "includes are processed first, then excludes."))
+  (merge StatQueryParams
+         {(s/optional-key :filter-include)
+          (describe String (str "Comma-separated list of keys to generate and return in each stat object. "
+                                "Defaults to all keys. If both this and filter-exclude are provided, "
+                                "includes are processed first, then excludes."))
 
-    (s/optional-key :filter-exclude)
-    (describe String (str "Comma-separated list of keys to exclude from each stat object. "
-                          "Defaults to no keys. If both this and filter-include are provided, "
-                          "includes are processed first, then excludes."))))
+          (s/optional-key :filter-exclude)
+          (describe String (str "Comma-separated list of keys to exclude from each stat object. "
+                                "Defaults to no keys. If both this and filter-include are provided, "
+                                "includes are processed first, then excludes."))}))
 
 (s/defschema DataStatInfo
   {:id
@@ -102,3 +101,18 @@
 (s/defschema FilteredStatusInfo
   {(s/optional-key :paths) (describe FilteredPathsMap "Paths info")
    (s/optional-key :ids) (describe FilteredDataIdsMap "IDs info")})
+
+;; Used only for display as documentation in Swagger UI
+(s/defschema StatResponsePathsMap
+  {:/path/from/request/to/a/folder (describe DirStatInfo "A folder's info")
+   :/path/from/request/to/a/file   (describe FileStatInfo "A file's info")})
+
+;; Used only for display as documentation in Swagger UI
+(s/defschema StatResponseIdsMap
+  {:some-folder-uuid (describe DirStatInfo "A folder's info")
+   :some-file-uuid   (describe FileStatInfo "A file's info")})
+
+;; Used only for display as documentation in Swagger UI
+(s/defschema StatResponse
+  {(s/optional-key :paths) (describe StatResponsePathsMap "A map of paths from the request to their status info")
+   (s/optional-key :ids) (describe StatResponseIdsMap "A map of ids from the request to their status info")})


### PR DESCRIPTION
This PR will import the remaining `/stat-gatherer` schemas and docs from `data-info.routes.stats` and `data-info.routes.schemas.stats` into `common-swagger-api.schema.stats`, and from `data-info.routes.schemas.common` into `common-swagger-api.schema.data`.