### PR TITLE
Core 971

### DIFF
--- a/src/common_swagger_api/schema/analyses.clj
+++ b/src/common_swagger_api/schema/analyses.clj
@@ -217,3 +217,47 @@
 (defschema AnalysisTimeLimit
   {:time_limit
    (describe String "Contains the seconds since the epoch for the analysis's time limit or the string 'null' if the time limit isn't set.")})
+
+(def ConcurrentJobLimitUsername
+  (describe String "The username associated with the limit"))
+
+(def ConcurrentJobLimitListingSummary
+  "List Concurrent Job Limits")
+
+(def ConcurrentJobLimitListingDescription
+  "Lists the concurrent job limits for all users who have one defined. The record describing the default limit contains
+   no username. Users without explicit limits defined will use the default limit.")
+
+(def ConcurrentJobLimitRetrievalSummary
+  "Get a User's Concurrent Job Limit")
+
+(def ConcurrentJobLimitRetrievalDescription
+  "Gets the concurrent job limit for a user. The limit will either be the limit that was explicitly set for the user
+   or the default limit. If the default limit is returned then there will be no username in the response body.")
+
+(def ConcurrentJobLimitUpdateSummary
+  "Update a User's Concurrent Job Limit")
+
+(def ConcurrentJobLimitUpdateDescription
+  "Updates the concurrent job limit for a user. The user's limit will be set explicitly even if it's equal to the
+   default limit.")
+
+(def ConcurrentJobLimitRemovalSummary
+  "Remove a User's Concurrent Job Limit")
+
+(def ConcurrentJobLimitRemovalDescription
+  "Removes the explicitly configured concurrent job limit for a user. This effectively returns the user's job limit
+   to whatever the default job limit is.")
+
+(defschema ConcurrentJobLimit
+  {(optional-key :username)
+   (describe String "The username of the limited user, omitted for the default setting")
+
+   :concurrent_jobs
+   (describe Long "The maximum number of concurrently running jobs")})
+
+(defschema ConcurrentJobLimits
+  {:limits (describe [ConcurrentJobLimit] "The list of concurrent job limits")})
+
+(defschema ConcurrentJobLimitUpdate
+  (st/dissoc ConcurrentJobLimit :username))

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -85,6 +85,11 @@
    If the `search` parameter is included, then the results are filtered by
    the App name, description, integrator's name, tool name, or category name the app is under.")
 
+(def SingleAppListingSummary "List An App")
+(def SingleAppListingDocs
+  "This service returns listing information for a single app. The Sonora UI uses this to provide a way to link
+   to a single app without displaying the app launch dialog.")
+
 (def AppPublishableSummary "Determine if an App Can be Made Public")
 (def AppPublishableDocs
   "A multi-step App can't be made public if any of the Tasks that are included in it are not public.


### PR DESCRIPTION
The changes for CORE-971 are covered by this PR. The changes for CORE-675 are covered by https://github.com/cyverse-de/common-swagger-api/pull/57. Both sets of changes can go into the same package version, but I wanted to have separate PRs for clarity (although I'm not entirely convinced that it's actually adding any clarity 😆).

The purpose of adding a separate endpoint for listing a single app in the DE is also to add clarity. Adapting the existing app search endpoint to work for listing a specified app ID seems potentially confusing. For example, what happens if the `app-id` and `search` parameters are both specified and they conflict (that is the app ID matches an app, but the search string would exclude the app)? I can imagine a valid argument for excluding the app because it doesn't match the search string. After all, maybe the caller only wants to list that specific app if it also matches the search string. I can also imagine a valid argument for including the app because the `app-id` parameter should override the search string. Given the confusion inherent in interactions between the `app-id` and `search` parameters (or the lack thereof), I decided it would probably be best to create a separate endpoint.
