### PR TITLE
CORE-1148 Enable write as analysis sharing permission

### DIFF
--- a/src/common_swagger_api/schema/apps/permission.clj
+++ b/src/common_swagger_api/schema/apps/permission.clj
@@ -72,7 +72,7 @@
    Note: like Tool sharing, this is a potentially slow operation.")
 
 (def AppPermissionEnum (enum "read" "write" "own" ""))
-(def AnalysisPermissionEnum (enum "read" "own" ""))
+(def AnalysisPermissionEnum AppPermissionEnum)
 (def ToolPermissionEnum AppPermissionEnum)
 
 (defschema PermissionListerQueryParams


### PR DESCRIPTION
We discussed this in Slack a while back, but nobody could think of a reason why `write` should be excluded as a valid permission for analyses.  This should make the sharing dialog's functionality complete since it was getting an error trying to request `write` permissions on analyses.