### PR TITLE
CORE-1353: updated dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,16 +5,17 @@
             :url "http://iplantcollaborative.org/sites/default/files/iPLANT-LICENSE.txt"}
   :deploy-repositories [["releases" :clojars]
                         ["snapshots" :clojars]]
-  :dependencies [[org.clojure/clojure "1.10.0"]
-                 [cheshire "5.8.1"]
-                 [metosin/compojure-api "1.1.12"]
-                 [metosin/schema-tools "0.11.0"]
-                 [org.cyverse/clojure-commons "3.0.3"]
+  :dependencies [[org.clojure/clojure "1.10.3"]
+                 [cheshire "5.10.0"]
+                 [metosin/compojure-api "1.1.13"]
+                 [metosin/schema-tools "0.12.3"]
+                 [org.cyverse/clojure-commons "3.0.6"]
                  [org.cyverse/heuristomancer "2.8.6"]
-                 [org.flatland/ordered "1.5.7"]]
+                 [org.flatland/ordered "1.5.9"]]
   :eastwood {:exclude-namespaces [common-swagger-api.schema.data.exists
                                   common-swagger-api.schema.data.tickets
                                   common-swagger-api.schema.stats]
              :linters [:wrong-arity :wrong-ns-form :wrong-pre-post :wrong-tag :misplaced-docstrings]}
-  :plugins [[test2junit "1.2.2"]
-            [jonase/eastwood "0.3.5"]])
+  :plugins [[lein-ancient "0.7.0"]
+            [test2junit "1.2.2"]
+            [jonase/eastwood "0.3.14"]])

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/common-swagger-api "3.0.11-SNAPSHOT"
+(defproject org.cyverse/common-swagger-api "3.1.0-SNAPSHOT"
   :description "Common library for Swagger documented RESTful APIs"
   :url "https://github.com/cyverse-de/common-swagger-api"
   :license {:name "BSD"


### PR DESCRIPTION
I encountered an error when I tried to run Terrain locally using Java 15. The error was occurring in `flatland/ordered`, and updating the dependency fixed that problem.

It appears that there are some dependency updates with breaking changes, so I'm going to bump the minor version of this library.

I updated all of the outdated dependencies:

## `cheshire` 5.8.1 to 5.10.0

The change log doesn't mention any breaking changes, and we've used Cheshire 5.10.0 in other libraries and services.

## `metosin/compojure-api` 1.1.12 to 1.1.13

The change log  mentions a breaking change, but it's just that support for Java 6 and Java 7 have been dropped. We use at least Java 8, so we should be okay there.

## `metosin/schema-tools` 0.11.0 to 0.12.3

The change log mentions some breaking changes for schema coercion that shouldn't affect us.

## `org.cyverse/clojure-commons` 3.0.3 to 3.0.6

There were some dependency updates, but these updates haven't caused problems in other libraries.

## `flatland/ordered` 1.5.7 to 1.5.9

This is the change that fixes the problem that we were having with Java 15. This project doesn't have a change log, but I didn't see anything in the comparison between the two versions that looked problematic.
