### PR TITLE
CORE-1430: updated the analysis sharing and unsharing response bodies

### DIFF
--- a/src/common_swagger_api/schema/apps/permission.clj
+++ b/src/common_swagger_api/schema/apps/permission.clj
@@ -166,12 +166,9 @@
 
 (defschema AnalysisSharingResponseElement
   (assoc AnalysisSharingRequestElement
-    :analysis_name                (describe NonBlankString "The analysis name")
-    :success                      (describe Boolean "A Boolean flag indicating whether the sharing request succeeded")
-    (optional-key :input_errors)  (describe [NonBlankString] "A list of any analysis input sharing errors")
-    (optional-key :outputs_error) (describe NonBlankString "A brief reason for any result folder sharing errors")
-    (optional-key :app_error)     (describe NonBlankString "A brief reason for any app sharing errors")
-    (optional-key :error)         (describe ErrorResponse "Information about any error that may have occurred")))
+    :analysis_name        (describe NonBlankString "The analysis name")
+    :ok                   (describe Boolean "A Boolean flag indicating whether or not the request passed validation")
+    (optional-key :error) (describe ErrorResponse "Information about any validation error that may have occurred")))
 
 (defschema SubjectAnalysisSharingRequestElement
   {:subject  (describe Subject "The user or group identification.")
@@ -190,12 +187,10 @@
   {:sharing (describe [SubjectAnalysisSharingResponseElement] "The list of sharing responses for individual subjects")})
 
 (defschema AnalysisUnsharingResponseElement
-  {:analysis_id                  (describe UUID "The analysis ID")
-   :analysis_name                (describe NonBlankString "The analysis name")
-   :success                      (describe Boolean "A Boolean flag indicating whether the unsharing request succeeded")
-   (optional-key :input_errors)  (describe [NonBlankString] "A list of any analysis input unsharing errors")
-   (optional-key :outputs_error) (describe NonBlankString "A brief reason for the result folder unsharing error")
-   (optional-key :error)         (describe ErrorResponse "Information about any error that may have occurred")})
+  {:analysis_id          (describe UUID "The analysis ID")
+   :analysis_name        (describe NonBlankString "The analysis name")
+   :ok                   (describe Boolean "A Boolean flag indicating whether or not the request passed validation")
+   (optional-key :error) (describe ErrorResponse "Information about any validation error that may have occurred")})
 
 (defschema SubjectAnalysisUnsharingRequestElement
   {:subject  (describe Subject "The user or group identification.")

--- a/src/common_swagger_api/schema/apps/permission.clj
+++ b/src/common_swagger_api/schema/apps/permission.clj
@@ -184,7 +184,11 @@
       (describe "The analysis sharing request.")))
 
 (defschema AnalysisSharingResponse
-  {:sharing (describe [SubjectAnalysisSharingResponseElement] "The list of sharing responses for individual subjects")})
+  {:sharing
+   (describe [SubjectAnalysisSharingResponseElement] "The list of sharing responses for individual subjects")
+
+   (optional-key :asyncTaskID)
+   (describe UUID "The ID of the asynchronous task being used to track the sharing request")})
 
 (defschema AnalysisUnsharingResponseElement
   {:analysis_id          (describe UUID "The analysis ID")
@@ -207,7 +211,10 @@
 
 (defschema AnalysisUnsharingResponse
   {:unsharing
-   (describe [SubjectAnalysisUnsharingResponseElement] "The list of unsharing responses for individual subjects")})
+   (describe [SubjectAnalysisUnsharingResponseElement] "The list of unsharing responses for individual subjects")
+
+   (optional-key :asyncTaskID)
+   (describe UUID "The ID of the asynchronous task being used to track the unsharing request")})
 
 (defschema ToolIdList
   (describe


### PR DESCRIPTION
The purpose of this change is to convert the analysis sharing and unsharing endpoints from synchronous to asynchronous. The response bodies can no longer indicate whether or not the analysis was shared or unshared successfully, so instead of returning a `success` flag for each analysis sharing or unsharing request, the endpoints will now return an `ok` flag indicating whether or not the initial validation would have passed.

The endpoints will not do any initial validation for apps, inputs, or output folders, so the corresponding keys are being removed. Note that these keys will still be present in the analysis sharing and unsharing notifications.

An initial validation failure will cause the entire request to be rejected and cause the endpoints to return a 400 status code, so if any of the sharing requests fail initial validation the caller will have to resubmit a corrected request in order for any of the analyses to be shared or unshared.
