### PR TITLE
CORE-1488 Add support for `:deprecated` routes flag

### DIFF
--- a/src/common_swagger_api/routes.clj
+++ b/src/common_swagger_api/routes.clj
@@ -6,6 +6,10 @@
   [_ path acc]
   (update-in acc [:swagger] assoc :description (slurp (io/resource path))))
 
+(defmethod compojure.api.meta/restructure-param :deprecated
+  [_ deprecated? acc]
+  (update-in acc [:swagger] assoc :deprecated deprecated?))
+
 (defn get-endpoint-delegate-block
   [service endpoint]
   (str "


### PR DESCRIPTION
This PR will add support for a `:deprecated` flag in our API routes, which is supported by Swagger/OpenAPI: https://swagger.io/docs/specification/paths-and-operations/

For example the following route will render Swagger docs as in the screenshot following this code example:
```clojure
(POST "/ezid" [request-id]
      :deprecated true
      :return PermanentIDRequestDetails
      :summary "Create a Permanent ID"
      :description "This endpoint is deprecated. Please use the `POST .../doi` endpoint above."
      (ok (create-permanent-id request-id)))
```
![image](https://user-images.githubusercontent.com/996408/136311902-9c8c7ea7-4cf0-4d50-a930-0b96818988da.png)
