### PR TITLE
CORE-316 Add version fields to app schemas

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.cyverse/common-swagger-api "3.2.4-SNAPSHOT"
+(defproject org.cyverse/common-swagger-api "3.3.0-SNAPSHOT"
   :description "Common library for Swagger documented RESTful APIs"
   :url "https://github.com/cyverse-de/common-swagger-api"
   :license {:name "BSD"

--- a/src/common_swagger_api/schema/analyses.clj
+++ b/src/common_swagger_api/schema/analyses.clj
@@ -79,9 +79,17 @@
    (describe Boolean "Indicates whether the parameter is visible in the app UI.")})
 
 (defschema AnalysisParameters
-  {:app_id     (describe String "The ID of the app used to perform the analysis.")
-   :system_id  SystemId
-   :parameters (describe [AnalysisParameter] "The list of parameters.")})
+  {:app_id
+   (describe String "The ID of the app used to perform the analysis.")
+
+   (optional-key :app_version_id)
+   (describe String "The version ID of the app used to perform the analysis.")
+
+   :system_id
+   SystemId
+
+   :parameters
+   (describe [AnalysisParameter] "The list of parameters.")})
 
 (defschema AnalysesRelauncherRequest
   {:analyses (describe [UUID] "The identifiers of the analyses to be relaunched.")})

--- a/src/common_swagger_api/schema/analyses/listing.clj
+++ b/src/common_swagger_api/schema/analyses/listing.clj
@@ -72,6 +72,9 @@
    :app_id
    (describe String "The ID of the app used to perform the analysis.")
 
+   (optional-key :app_version_id)
+   (describe String "The version ID of the app used to perform the analysis.")
+
    :system_id
    SystemId
 

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -543,6 +543,9 @@
           :disabled
           AppDisabledParam
 
+          (optional-key :version)
+          (describe String "The App's latest version")
+
           :integrator_email
           (describe String "The App integrator's email address")
 

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -700,7 +700,7 @@
 
 (defschema AppRequest
   (-> App
-      (->optional-param :id)
+      (st/optional-keys [:id :version :version_id])
       (assoc OptionalGroupsKey (describe [AppGroupRequest] GroupListDocs)
              OptionalToolsKey  (describe [AppToolRequest] ToolListDocs))))
 

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -152,6 +152,8 @@
 (def AppDocParam (describe String "The App's documentation"))
 (def AppDocUrlParam (describe String "The App's documentation URL"))
 (def AppIdParam (describe UUID "A UUID that is used to identify the App"))
+(def AppLatestVersionParam (describe String "The App's latest version"))
+(def AppLatestVersionIdParam (describe String "The latest App version ID"))
 (def AppPublicParam (describe Boolean "Whether the App has been published and is viewable by all users"))
 (def AppReferencesParam (describe [String] "The App's references"))
 (def StringAppIdParam (describe NonBlankString "The App identifier"))
@@ -490,6 +492,9 @@
   {(optional-key :app_id)
    StringAppIdParam
 
+   (optional-key :version_id)
+   AppLatestVersionIdParam
+
    :documentation
    AppDocParam
 
@@ -546,10 +551,10 @@
           AppDisabledParam
 
           (optional-key :version)
-          (describe String "The App's latest version")
+          AppLatestVersionParam
 
           (optional-key :version_id)
-          (describe String "The latest App version ID")
+          AppLatestVersionIdParam
 
           :integrator_email
           (describe String "The App integrator's email address")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -370,7 +370,10 @@
           (optional-key :references) AppReferencesParam
           OptionalGroupsKey          (describe [AppGroup] GroupListDocs)}))
 
-(def AppLabelUpdateRequest (describe App "The App to update."))
+(defschema AppLabelUpdateRequest
+  (st/optional-keys
+    (describe App "The App to update.")
+    [:version :version_id]))
 
 (defschema AppFileParameterDetails
   {:id          (describe String "The Parameter's ID")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -462,6 +462,8 @@
 (defschema AppDetails
   (-> AppBase
       (merge {:id                   (describe String "The app identifier.")
+              :version              (describe String "The App's version")
+              :version_id           (describe String "The App's version ID")
               :tools                (describe [AppDetailsTool] ToolListDocs)
               :deleted              AppDeletedParam
               :disabled             AppDisabledParam
@@ -545,6 +547,9 @@
 
           (optional-key :version)
           (describe String "The App's latest version")
+
+          (optional-key :version_id)
+          (describe String "The latest App version ID")
 
           :integrator_email
           (describe String "The App integrator's email address")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -152,6 +152,8 @@
 (def AppDocParam (describe String "The App's documentation"))
 (def AppDocUrlParam (describe String "The App's documentation URL"))
 (def AppIdParam (describe UUID "A UUID that is used to identify the App"))
+(def AppVersionParam (describe String "The App's version"))
+(def AppVersionIdParam (describe UUID "The App's version ID"))
 (def AppLatestVersionParam (describe String "The App's latest version"))
 (def AppLatestVersionIdParam (describe String "The latest App version ID"))
 (def AppPublicParam (describe Boolean "Whether the App has been published and is viewable by all users"))
@@ -362,7 +364,9 @@
 
 (defschema App
   (merge AppBase
-         {OptionalToolsKey           (describe [(merge Tool {OptionalDeprecatedKey ToolDeprecatedParam})] ToolListDocs)
+         {:version                   AppVersionParam
+          :version_id                AppVersionIdParam
+          OptionalToolsKey           (describe [(merge Tool {OptionalDeprecatedKey ToolDeprecatedParam})] ToolListDocs)
           (optional-key :references) AppReferencesParam
           OptionalGroupsKey          (describe [AppGroup] GroupListDocs)}))
 
@@ -464,8 +468,8 @@
 (defschema AppDetails
   (-> AppBase
       (merge {:id                   (describe String "The app identifier.")
-              :version              (describe String "The App's version")
-              :version_id           (describe String "The App's version ID")
+              :version              AppVersionParam
+              :version_id           AppVersionIdParam
               :tools                (describe [AppDetailsTool] ToolListDocs)
               :deleted              AppDeletedParam
               :disabled             AppDisabledParam

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -341,6 +341,8 @@
   {:id                              AppIdParam
    :name                            (describe String "The App's name")
    :description                     (describe String "The App's description")
+   (optional-key :version)          AppVersionParam
+   (optional-key :version_id)       AppVersionIdParam
    (optional-key :integration_date) (describe Date "The App's Date of public submission")
    (optional-key :edited_date)      (describe Date "The App's Date of its last edit")
    (optional-key :system_id)        SystemId})
@@ -364,16 +366,11 @@
 
 (defschema App
   (merge AppBase
-         {:version                   AppVersionParam
-          :version_id                AppVersionIdParam
-          OptionalToolsKey           (describe [(merge Tool {OptionalDeprecatedKey ToolDeprecatedParam})] ToolListDocs)
+         {OptionalToolsKey           (describe [(merge Tool {OptionalDeprecatedKey ToolDeprecatedParam})] ToolListDocs)
           (optional-key :references) AppReferencesParam
           OptionalGroupsKey          (describe [AppGroup] GroupListDocs)}))
 
-(defschema AppLabelUpdateRequest
-  (st/optional-keys
-    (describe App "The App to update.")
-    [:version :version_id]))
+(def AppLabelUpdateRequest (describe App "The App to update."))
 
 (defschema AppFileParameterDetails
   {:id          (describe String "The Parameter's ID")
@@ -471,8 +468,6 @@
 (defschema AppDetails
   (-> AppBase
       (merge {:id                   (describe String "The app identifier.")
-              :version              AppVersionParam
-              :version_id           AppVersionIdParam
               :tools                (describe [AppDetailsTool] ToolListDocs)
               :deleted              AppDeletedParam
               :disabled             AppDisabledParam
@@ -488,9 +483,9 @@
                                      [AppDetailCategory]
                                      "The list of Categories the integrator wishes to associate with the App")}
              OntologyHierarchyList)
-      (->optional-param :wiki_url)
-      (->optional-param :job_stats)
-      (->optional-param :hierarchies)))
+      (st/optional-keys [:wiki_url
+                         :job_stats
+                         :hierarchies])))
 
 (defschema AppToolListing
   {:tools (describe [AppDetailsTool] "Listing of App Tools")})
@@ -700,7 +695,7 @@
 
 (defschema AppRequest
   (-> App
-      (st/optional-keys [:id :version :version_id])
+      (st/optional-keys [:id])
       (assoc OptionalGroupsKey (describe [AppGroupRequest] GroupListDocs)
              OptionalToolsKey  (describe [AppToolRequest] ToolListDocs))))
 
@@ -709,9 +704,9 @@
 
 (defschema AppPreviewRequest
   (-> App
-      (->optional-param :id)
-      (->optional-param :name)
-      (->optional-param :description)
+      (st/optional-keys [:id
+                         :name
+                         :description])
       (assoc OptionalGroupsKey (describe [AppGroupRequest] GroupListDocs)
              (optional-key :is_public) AppPublicParam
              OptionalToolsKey (describe [AppToolRequest] ToolListDocs))

--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -10,7 +10,8 @@
                 SortFieldOptionalKey]]
         [schema.core :only [defschema enum optional-key]])
   (:require [clojure.set :as sets]
-            [common-swagger-api.schema.apps :as apps])
+            [common-swagger-api.schema.apps :as apps]
+            [schema-tools.core :as st])
   (:import [java.util Date UUID]))
 
 (def AdminAppPatchSummary "Update App Details and Labels")
@@ -122,12 +123,10 @@
 
 (defschema AdminAppPatchRequest
   (-> apps/AppBase
-      (->optional-param :id)
-      (->optional-param :name)
-      (->optional-param :description)
-      (assoc (optional-key :version) apps/AppVersionParam
-             (optional-key :version_id) apps/AppVersionIdParam
-             (optional-key :extra) AppExtraInfo
+      (st/optional-keys [:id
+                         :name
+                         :description])
+      (assoc (optional-key :extra) AppExtraInfo
              (optional-key :wiki_url) apps/AppDocUrlParam
              (optional-key :references) apps/AppReferencesParam
              (optional-key :deleted) apps/AppDeletedParam

--- a/src/common_swagger_api/schema/apps/admin/apps.clj
+++ b/src/common_swagger_api/schema/apps/admin/apps.clj
@@ -125,7 +125,9 @@
       (->optional-param :id)
       (->optional-param :name)
       (->optional-param :description)
-      (assoc (optional-key :extra) AppExtraInfo
+      (assoc (optional-key :version) apps/AppVersionParam
+             (optional-key :version_id) apps/AppVersionIdParam
+             (optional-key :extra) AppExtraInfo
              (optional-key :wiki_url) apps/AppDocUrlParam
              (optional-key :references) apps/AppReferencesParam
              (optional-key :deleted) apps/AppDeletedParam

--- a/src/common_swagger_api/schema/apps/pipeline.clj
+++ b/src/common_swagger_api/schema/apps/pipeline.clj
@@ -1,7 +1,10 @@
 (ns common-swagger-api.schema.apps.pipeline
-  (:use [common-swagger-api.schema :only [->optional-param describe]]
-        [common-swagger-api.schema.apps :only [AppTaskListing]]
-        [schema.core :only [defschema optional-key Keyword]])
+  (:require [common-swagger-api.schema :refer [describe]]
+            [common-swagger-api.schema.apps :refer [AppTaskListing
+                                                    AppVersionParam
+                                                    AppVersionIdParam]]
+            [schema.core :refer [defschema optional-key Keyword]]
+            [schema-tools.core :as st])
   (:import [java.util UUID]))
 
 (def PipelineCopySummary "Make a Copy of a Pipeline Available for Editing")
@@ -57,6 +60,12 @@
     {:id
      (describe UUID "The pipeline's ID")
 
+     :version
+     AppVersionParam
+
+     :version_id
+     AppVersionIdParam
+
      :steps
      (describe [PipelineStep] "The Pipeline's steps")
 
@@ -65,10 +74,10 @@
 
 (defschema PipelineUpdateRequest
   (-> Pipeline
-      (->optional-param :tasks)
+      (st/optional-keys [:tasks :version :version_id])
       (describe "The Pipeline to update.")))
 
 (defschema PipelineCreateRequest
   (-> PipelineUpdateRequest
-      (->optional-param :id)
+      (st/optional-keys [:id])
       (describe "The Pipeline to create.")))

--- a/src/common_swagger_api/schema/apps/pipeline.clj
+++ b/src/common_swagger_api/schema/apps/pipeline.clj
@@ -1,8 +1,6 @@
 (ns common-swagger-api.schema.apps.pipeline
   (:require [common-swagger-api.schema :refer [describe]]
-            [common-swagger-api.schema.apps :refer [AppTaskListing
-                                                    AppVersionParam
-                                                    AppVersionIdParam]]
+            [common-swagger-api.schema.apps :refer [AppTaskListing]]
             [schema.core :refer [defschema optional-key Keyword]]
             [schema-tools.core :as st])
   (:import [java.util UUID]))
@@ -60,12 +58,6 @@
     {:id
      (describe UUID "The pipeline's ID")
 
-     :version
-     AppVersionParam
-
-     :version_id
-     AppVersionIdParam
-
      :steps
      (describe [PipelineStep] "The Pipeline's steps")
 
@@ -74,7 +66,7 @@
 
 (defschema PipelineUpdateRequest
   (-> Pipeline
-      (st/optional-keys [:tasks :version :version_id])
+      (st/optional-keys [:tasks])
       (describe "The Pipeline to update.")))
 
 (defschema PipelineCreateRequest

--- a/src/common_swagger_api/schema/quicklaunches.clj
+++ b/src/common_swagger_api/schema/quicklaunches.clj
@@ -5,16 +5,6 @@
             [schema-tools.core :as st])
   (:import [java.util UUID]))
 
-(s/defschema Submission
-  {:id
-   (describe UUID "The UUID for this submission")
-
-   :submission
-   AnalysisSubmission})
-
-(s/defschema NewSubmission
-  (st/dissoc Submission :id))
-
 (s/defschema QuickLaunch
   {:id
    (describe UUID "The UUID for the quick launch")
@@ -31,6 +21,9 @@
    :app_id
    (describe UUID "The UUID for the app the quick launch is associated with")
 
+   :app_version_id
+   (describe UUID "The UUID for the app version the quick launch is associated with")
+
    (s/optional-key :is_public)
    (describe Boolean "Whether the quick launch is publicly available. Defaults to false")
 
@@ -38,7 +31,9 @@
    AnalysisSubmission})
 
 (s/defschema NewQuickLaunch
-  (st/dissoc QuickLaunch :id :user)) ;user should be included in the request query params
+  (-> QuickLaunch
+      (st/dissoc :id :user) ;user should be included in the request query params
+      (st/optional-keys [:app_version_id])))
 
 (s/defschema UpdateQuickLaunch
   (-> QuickLaunch
@@ -57,12 +52,6 @@
 
 (s/defschema NewQuickLaunchFavorite
   (st/dissoc QuickLaunchFavorite :id :user)) ;user is in query params, id is auto-assigned.
-
-; Mostly just useful for admin operations. Users will either create or remove favorites.
-(s/defschema UpdateQuickLaunchFavorite
-  (-> QuickLaunchFavorite
-      (st/dissoc :id)
-      (st/optional-keys-schema)))
 
 (s/defschema QuickLaunchUserDefault
   {:id


### PR DESCRIPTION
This PR will add version fields to app schemas required for PRs related to cyverse-de/de-database#10.

* Added `version_id` field to the `AppDocumentation` schema.
* Added optional `version` and `version_id` fields to the `AppBase` schema, which adds these fields to the following schemas:
  * `AppListingDetail` (see #73 for previous comments).
  * `AppDetails`
  * `App` and related schemas
  * `AdminAppPatchRequest`
  * `AppJobView`
  * `AppTaskListing`
  * `Pipeline` and related schemas

A side effect of adding version fields to those schemas means they are also included in the following schemas:
* `AdminAppDetails`
* `AdminAppListingDetail`
* `AdminAppPatchRequest`
* `AppPreviewRequest`
* `AppRequest`
* `PublishAppRequest`

Also added an optional `app_version_id` field to the `BaseAnalysis`, `AnalysisParameters`, and `QuickLaunch` schemas.

A side effect of adding version fields to those schemas means they are also included in the following schemas:
* `AdminAnalysisList`
* `AnalysisList`
* `AnalysisUpdate`
* `AnalysisUpdate`
* `NewQuickLaunch`
* `UpdateQuickLaunch`
