### PR TITLE
Allow max_cpu_cores to be set in a submission

### DIFF
--- a/src/common_swagger_api/schema/analyses.clj
+++ b/src/common_swagger_api/schema/analyses.clj
@@ -107,6 +107,7 @@
 (defschema AnalysisStepResourceRequirements
   (st/select-keys AppStepResourceRequirements [:min_memory_limit
                                                :min_cpu_cores
+                                               :max_cpu_cures
                                                :min_disk_space
                                                :step_number]))
 

--- a/src/common_swagger_api/schema/analyses.clj
+++ b/src/common_swagger_api/schema/analyses.clj
@@ -107,7 +107,7 @@
 (defschema AnalysisStepResourceRequirements
   (st/select-keys AppStepResourceRequirements [:min_memory_limit
                                                :min_cpu_cores
-                                               :max_cpu_cures
+                                               :max_cpu_cores
                                                :min_disk_space
                                                :step_number]))
 

--- a/src/common_swagger_api/schema/containers.clj
+++ b/src/common_swagger_api/schema/containers.clj
@@ -32,7 +32,7 @@
        (s/optional-key :memory_limit)      (describe Long "The amount of memory (in bytes) that the tool container is restricted to")
        (s/optional-key :min_memory_limit)  (describe Long "The minimum about of memory (in bytes) that is required to run the tool container")
        (s/optional-key :min_cpu_cores)     (describe Double "The minimum number of CPU cores needed to run the tool container")
-       (s/optional-key :max_cpu_cores)     Double
+       (s/optional-key :max_cpu_cores)     (describe Double "The maximum number of CPU cores allowed when running the tool container")
        (s/optional-key :min_disk_space)    (describe Long "The minimum amount of disk space needed to run the tool container")
        (s/optional-key :network_mode)      (describe s/Str "The network mode for the tool container")
        (s/optional-key :working_directory) (describe s/Str "The working directory in the tool container")


### PR DESCRIPTION
Adds max_cpu_cores to the list of keys allowed in the AnalysisStepResourceRequirements schema. Also adds a brief description of the field.