### PR TITLE
CORE-1744: moved the schema definitions for Agave job status updates …

### DIFF
--- a/src/common_swagger_api/schema/callbacks.clj
+++ b/src/common_swagger_api/schema/callbacks.clj
@@ -1,0 +1,12 @@
+(ns common-swagger-api.schema.callbacks
+  (:use [common-swagger-api.schema :only [describe]]
+        [schema.core :only [defschema optional-key Keyword Any]]))
+
+(defschema AgaveJobStatusUpdateParams
+  {:status      (describe String "The status assigned to the job by Agave")
+   :external-id (describe String "Agave's identifier for the job")
+   :end-time    (describe String "The analysis completion timestamp")})
+
+(defschema AgaveJobStatusUpdate
+  {:lastUpdated (describe String "The time the job status was last updated")
+   Keyword      Any})


### PR DESCRIPTION
…here

The reason for making this change is to update the DE so that Agave job status update callbacks no longer bypass Terrain. When support for Agave jobs was initially added to the DE, Terrain had no way to support unauthenticated API calls, so all job status update callbacks had to bypass Terrain in order to work (or at least to work easily). Terrain can now support unauthenticated calls, so there is no longer a need to bypass it.

The mechanism we used to bypass terrain was to add a route to the nginx instance that ran along side the DE. In current deployments (which all use Kubernetes), this container is deployed as a sidecar container in the old DE UI pod. The old DE UI has been replaced, so it would be nice to simplify the configuration of the nginx instance as well.

Ideally, we'd like to avoid direct nginx configuration (because it's difficult to customize without using a template system) and use something that's easier to customize. The nginx ingress controller should work, but it's difficult to create URL rewrite rules for specific paths. Eliminating this custom path also eliminates one case where the URL has to be modified, which eliminates one barrier to using the nginx ingress controller.