### PR TITLE
CORE-1808 Add overall_job_type field to AppListingDetail schema

### DIFF
--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -533,6 +533,9 @@
           :app_type
           (describe String "The type ID of the App")
 
+          (optional-key :overall_job_type)
+          (describe String "The type of the App's tool(s)")
+
           :can_favor
           (describe Boolean "Whether the current user can favorite this App")
 


### PR DESCRIPTION
This PR will add an optional `overall_job_type` field to the `AppListingDetail` schema, allowing app listing and detail endpoints to return this info from the column of the same name returned by the [db's app listing view](https://github.com/cyverse-de/de-database/blob/e89e330fcf762237f24e8e3495f1f235d23ced05/migrations/000034_app_versions_listing.up.sql#L26-L29).

I don't know if we want to name this API JSON field anything different than the name from the db's app listing view. I considered using `app_type`, but that is already used to label `DE` vs. `External` apps.