### PR TITLE
Add an 'include-defaults' flag for tool details requests

### DIFF
--- a/src/common_swagger_api/schema/tools.clj
+++ b/src/common_swagger_api/schema/tools.clj
@@ -112,6 +112,9 @@
           (optional-key :public) (describe Boolean
                                            "Set to `true` to list only public Tools, `false` to list only private Tools,
                                             or leave unset to list all Tools.")}))
+(defschema ToolDetailsParams
+  {(optional-key :include-defaults)
+   (describe Boolean "Flag to include defaults set by configuration or not")})
 
 (defschema PrivateToolDeleteParams
   {(optional-key :force-delete)


### PR DESCRIPTION
in order to allow excluding them for 'edit tool' forms, where we don't want to have the form think that the default is a tool-specific configured value