### PR TITLE
CORE-2075: made the `created_by` field in group details optional

### DIFF
--- a/src/common_swagger_api/schema/groups.clj
+++ b/src/common_swagger_api/schema/groups.clj
@@ -65,7 +65,7 @@
      :created_at
      (describe Long (str "The date and time the " group-descriptor " was created (ms since epoch)"))
 
-     :created_by
+     (s/optional-key :created_by)
      (describe String (str "The ID of the subject who created the " group-descriptor))
 
      (s/optional-key :created_by_detail)


### PR DESCRIPTION
The `created_by` field isn't always populated. I think that this is because some subjects have been removed from LDAP. I made the field optional because I think that's the easiest solution. If there are any downstream repositories that are affected by this then we'll have to address those errors as well.