### PR TITLE
Add a GPU models list to the schemas for tool/apps/analyses

### DIFF
--- a/src/common_swagger_api/schema/analyses.clj
+++ b/src/common_swagger_api/schema/analyses.clj
@@ -119,6 +119,7 @@
                                                :min_gpus
                                                :max_gpus
                                                :min_disk_space
+                                               :gpu_models
                                                :step_number]))
 
 (defschema AnalysisSubmission

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -438,6 +438,7 @@
                        :max_cpu_cores
                        :min_gpus
                        :max_gpus
+                       :gpu_models
                        :min_disk_space])
       (merge {(optional-key :default_max_cpu_cores) (describe Double "The default limit of CPU cores requested to run the tool container")
               (optional-key :default_cpu_cores)     (describe Double "The default minimum of CPU cores requested to run the tool container")

--- a/src/common_swagger_api/schema/apps.clj
+++ b/src/common_swagger_api/schema/apps.clj
@@ -446,6 +446,7 @@
               (optional-key :default_disk_space)    (describe Long "The default amount of disk space requested to run the tool container")
               (optional-key :default_max_gpus)      (describe Int "The default limit for GPUs for running the tool container")
               (optional-key :default_gpus)          (describe Int "The default minimum for GPUs requested for running the tool container")
+              (optional-key :default_gpu_models)    (describe [s/Str] "The default list of acceptable GPU models")
               :step_number                          (describe Int "The sequential step number of the Tool in the analysis")})
       (describe "The Tool resource requirements for this step")))
 

--- a/src/common_swagger_api/schema/containers.clj
+++ b/src/common_swagger_api/schema/containers.clj
@@ -36,6 +36,7 @@
        (s/optional-key :min_gpus)          (describe s/Int "The minimum number of GPUs needed to run the tool container")
        (s/optional-key :max_gpus)          (describe s/Int "The maximum number of GPUs allowed when running the tool container")
        (s/optional-key :min_disk_space)    (describe Long "The minimum amount of disk space needed to run the tool container")
+       (s/optional-key :gpu_models)        (describe [s/Str] "The GPU models that work with this tool container. Empty means no limitation on GPU model.")
        (s/optional-key :network_mode)      (describe s/Str "The network mode for the tool container")
        (s/optional-key :working_directory) (describe s/Str "The working directory in the tool container")
        (s/optional-key :name)              (describe s/Str "The name given to the tool container")


### PR DESCRIPTION
I _think_ I don't need to add this to the list of `default_*` properties on things, but if needed I can change it to do that too.